### PR TITLE
feat(home): Add Tokenized Grainient Hero Background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "idb": "^8.0.3",
         "lucide-react": "^0.562.0",
         "minisearch": "^7.2.0",
+        "ogl": "^1.0.11",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "zustand": "^5.0.9"
@@ -6883,6 +6884,12 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ogl/-/ogl-1.0.11.tgz",
+      "integrity": "sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==",
+      "license": "Unlicense"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -8744,7 +8751,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8761,7 +8767,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8778,7 +8783,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8795,7 +8799,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8812,7 +8815,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8829,7 +8831,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8846,7 +8847,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8863,7 +8863,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8880,7 +8879,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8897,7 +8895,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8914,7 +8911,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8931,7 +8927,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8948,7 +8943,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8965,7 +8959,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8982,7 +8975,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8999,7 +8991,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9016,7 +9007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9033,7 +9023,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9050,7 +9039,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9067,7 +9055,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9084,7 +9071,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9101,7 +9087,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9118,7 +9103,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9135,7 +9119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9152,7 +9135,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9169,7 +9151,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "idb": "^8.0.3",
     "lucide-react": "^0.562.0",
     "minisearch": "^7.2.0",
+    "ogl": "^1.0.11",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "zustand": "^5.0.9"

--- a/src/components/ui/Grainient.tsx
+++ b/src/components/ui/Grainient.tsx
@@ -1,0 +1,363 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Mesh, Program, Renderer, Triangle } from 'ogl';
+
+interface GrainientProps {
+  timeSpeed?: number;
+  colorBalance?: number;
+  warpStrength?: number;
+  warpFrequency?: number;
+  warpSpeed?: number;
+  warpAmplitude?: number;
+  blendAngle?: number;
+  blendSoftness?: number;
+  rotationAmount?: number;
+  noiseScale?: number;
+  grainAmount?: number;
+  grainScale?: number;
+  grainAnimated?: boolean;
+  contrast?: number;
+  gamma?: number;
+  saturation?: number;
+  centerX?: number;
+  centerY?: number;
+  zoom?: number;
+  color1?: string;
+  darkColor1?: string;
+  color2?: string;
+  darkColor2?: string;
+  color3?: string;
+  className?: string;
+  overlayClassName?: string;
+}
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return [1, 1, 1];
+  return [
+    parseInt(result[1], 16) / 255,
+    parseInt(result[2], 16) / 255,
+    parseInt(result[3], 16) / 255,
+  ];
+};
+
+const cssColorToRgb = (color: string): [number, number, number] => {
+  if (typeof document === 'undefined') {
+    return [1, 1, 1];
+  }
+
+  const probe = document.createElement('span');
+  probe.style.color = color;
+  probe.style.display = 'none';
+  document.body.appendChild(probe);
+  const computed = getComputedStyle(probe).color;
+  document.body.removeChild(probe);
+
+  if (computed.startsWith('#')) {
+    return hexToRgb(computed);
+  }
+
+  const rgbMatch = computed.match(/rgba?\(([^)]+)\)/i);
+  if (rgbMatch) {
+    const parts = rgbMatch[1].split(/[,\s/]+/).filter(Boolean);
+    if (parts.length >= 3) {
+      return [
+        Number(parts[0]) / 255,
+        Number(parts[1]) / 255,
+        Number(parts[2]) / 255,
+      ];
+    }
+  }
+
+  return hexToRgb(color);
+};
+
+const vertex = `#version 300 es
+in vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const fragment = `#version 300 es
+precision highp float;
+uniform vec2 iResolution;
+uniform float iTime;
+uniform float uTimeSpeed;
+uniform float uColorBalance;
+uniform float uWarpStrength;
+uniform float uWarpFrequency;
+uniform float uWarpSpeed;
+uniform float uWarpAmplitude;
+uniform float uBlendAngle;
+uniform float uBlendSoftness;
+uniform float uRotationAmount;
+uniform float uNoiseScale;
+uniform float uGrainAmount;
+uniform float uGrainScale;
+uniform float uGrainAnimated;
+uniform float uContrast;
+uniform float uGamma;
+uniform float uSaturation;
+uniform vec2 uCenterOffset;
+uniform float uZoom;
+uniform vec3 uColor1;
+uniform vec3 uColor2;
+uniform vec3 uColor3;
+out vec4 fragColor;
+#define S(a,b,t) smoothstep(a,b,t)
+mat2 Rot(float a){float s=sin(a),c=cos(a);return mat2(c,-s,s,c);} 
+vec2 hash(vec2 p){p=vec2(dot(p,vec2(2127.1,81.17)),dot(p,vec2(1269.5,283.37)));return fract(sin(p)*43758.5453);} 
+float noise(vec2 p){vec2 i=floor(p),f=fract(p),u=f*f*(3.0-2.0*f);float n=mix(mix(dot(-1.0+2.0*hash(i+vec2(0.0,0.0)),f-vec2(0.0,0.0)),dot(-1.0+2.0*hash(i+vec2(1.0,0.0)),f-vec2(1.0,0.0)),u.x),mix(dot(-1.0+2.0*hash(i+vec2(0.0,1.0)),f-vec2(0.0,1.0)),dot(-1.0+2.0*hash(i+vec2(1.0,1.0)),f-vec2(1.0,1.0)),u.x),u.y);return 0.5+0.5*n;}
+void mainImage(out vec4 o, vec2 C){
+  float t=iTime*uTimeSpeed;
+  vec2 uv=C/iResolution.xy;
+  float ratio=iResolution.x/iResolution.y;
+  vec2 tuv=uv-0.5+uCenterOffset;
+  tuv/=max(uZoom,0.001);
+
+  float degree=noise(vec2(t*0.1,tuv.x*tuv.y)*uNoiseScale);
+  tuv.y*=1.0/ratio;
+  tuv*=Rot(radians((degree-0.5)*uRotationAmount+180.0));
+  tuv.y*=ratio;
+
+  float frequency=uWarpFrequency;
+  float ws=max(uWarpStrength,0.001);
+  float amplitude=uWarpAmplitude/ws;
+  float warpTime=t*uWarpSpeed;
+  tuv.x+=sin(tuv.y*frequency+warpTime)/amplitude;
+  tuv.y+=sin(tuv.x*(frequency*1.5)+warpTime)/(amplitude*0.5);
+
+  vec3 colLav=uColor1;
+  vec3 colOrg=uColor2;
+  vec3 colDark=uColor3;
+  float b=uColorBalance;
+  float s=max(uBlendSoftness,0.0);
+  mat2 blendRot=Rot(radians(uBlendAngle));
+  float blendX=(tuv*blendRot).x;
+  float edge0=-0.3-b-s;
+  float edge1=0.2-b+s;
+  float v0=0.5-b+s;
+  float v1=-0.3-b-s;
+  vec3 layer1=mix(colDark,colOrg,S(edge0,edge1,blendX));
+  vec3 layer2=mix(colOrg,colLav,S(edge0,edge1,blendX));
+  vec3 col=mix(layer1,layer2,S(v0,v1,tuv.y));
+
+  vec2 grainUv=uv*max(uGrainScale,0.001);
+  if(uGrainAnimated>0.5){grainUv+=vec2(iTime*0.05);} 
+  float grain=fract(sin(dot(grainUv,vec2(12.9898,78.233)))*43758.5453);
+  col+=(grain-0.5)*uGrainAmount;
+
+  col=(col-0.5)*uContrast+0.5;
+  float luma=dot(col,vec3(0.2126,0.7152,0.0722));
+  col=mix(vec3(luma),col,uSaturation);
+  col=pow(max(col,0.0),vec3(1.0/max(uGamma,0.001)));
+  col=clamp(col,0.0,1.0);
+
+  o=vec4(col,1.0);
+}
+void main(){
+  vec4 o=vec4(0.0);
+  mainImage(o,gl_FragCoord.xy);
+  fragColor=o;
+}
+`;
+
+const Grainient: React.FC<GrainientProps> = ({
+  timeSpeed = 0.25,
+  colorBalance = 0.0,
+  warpStrength = 1.0,
+  warpFrequency = 5.0,
+  warpSpeed = 2.0,
+  warpAmplitude = 50.0,
+  blendAngle = 0.0,
+  blendSoftness = 0.05,
+  rotationAmount = 500.0,
+  noiseScale = 2.0,
+  grainAmount = 0.1,
+  grainScale = 2.0,
+  grainAnimated = false,
+  contrast = 1.5,
+  gamma = 1.0,
+  saturation = 1.0,
+  centerX = 0.0,
+  centerY = 0.0,
+  zoom = 0.9,
+  color1 = '#FF9FFC',
+  darkColor1,
+  color2 = '#5227FF',
+  darkColor2,
+  color3 = '#B19EEF',
+  className = '',
+  overlayClassName = '',
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [resolvedColor1, setResolvedColor1] = useState(color1);
+  const [resolvedColor2, setResolvedColor2] = useState(color2);
+  const [isWebglAvailable, setIsWebglAvailable] = useState(true);
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const getColor1 = () => {
+      const isDark = root.classList.contains('dark');
+      return isDark && darkColor1 ? darkColor1 : color1;
+    };
+    const getColor2 = () => {
+      const isDark = root.classList.contains('dark');
+      return isDark && darkColor2 ? darkColor2 : color2;
+    };
+
+    setResolvedColor1(getColor1());
+    setResolvedColor2(getColor2());
+
+    const observer = new MutationObserver(() => {
+      const nextColor1 = getColor1();
+      const nextColor2 = getColor2();
+      setResolvedColor1((prev) => (prev === nextColor1 ? prev : nextColor1));
+      setResolvedColor2((prev) => (prev === nextColor2 ? prev : nextColor2));
+    });
+
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [color1, darkColor1, color2, darkColor2]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let renderer: Renderer | null = null;
+    let ro: ResizeObserver | null = null;
+    let raf = 0;
+    let canvas: HTMLCanvasElement | null = null;
+    const container = containerRef.current;
+
+    try {
+      renderer = new Renderer({
+        webgl: 2,
+        alpha: true,
+        antialias: false,
+        dpr: Math.min(window.devicePixelRatio || 1, 2),
+      });
+
+      const gl = renderer.gl;
+      canvas = gl.canvas as HTMLCanvasElement;
+      canvas.style.width = '100%';
+      canvas.style.height = '100%';
+      canvas.style.display = 'block';
+      container.insertBefore(canvas, container.firstChild);
+
+      const geometry = new Triangle(gl);
+      const program = new Program(gl, {
+        vertex,
+        fragment,
+        uniforms: {
+          iTime: { value: 0 },
+          iResolution: { value: new Float32Array([1, 1]) },
+          uTimeSpeed: { value: timeSpeed },
+          uColorBalance: { value: colorBalance },
+          uWarpStrength: { value: warpStrength },
+          uWarpFrequency: { value: warpFrequency },
+          uWarpSpeed: { value: warpSpeed },
+          uWarpAmplitude: { value: warpAmplitude },
+          uBlendAngle: { value: blendAngle },
+          uBlendSoftness: { value: blendSoftness },
+          uRotationAmount: { value: rotationAmount },
+          uNoiseScale: { value: noiseScale },
+          uGrainAmount: { value: grainAmount },
+          uGrainScale: { value: grainScale },
+          uGrainAnimated: { value: grainAnimated ? 1.0 : 0.0 },
+          uContrast: { value: contrast },
+          uGamma: { value: gamma },
+          uSaturation: { value: saturation },
+          uCenterOffset: { value: new Float32Array([centerX, centerY]) },
+          uZoom: { value: zoom },
+          uColor1: { value: new Float32Array(cssColorToRgb(resolvedColor1)) },
+          uColor2: { value: new Float32Array(cssColorToRgb(resolvedColor2)) },
+          uColor3: { value: new Float32Array(cssColorToRgb(color3)) },
+        },
+      });
+
+      const mesh = new Mesh(gl, { geometry, program });
+
+      const setSize = () => {
+        const rect = container.getBoundingClientRect();
+        const width = Math.max(1, Math.floor(rect.width));
+        const height = Math.max(1, Math.floor(rect.height));
+        renderer?.setSize(width, height);
+        const res = (program.uniforms.iResolution as { value: Float32Array }).value;
+        res[0] = gl.drawingBufferWidth;
+        res[1] = gl.drawingBufferHeight;
+      };
+
+      ro = new ResizeObserver(setSize);
+      ro.observe(container);
+      setSize();
+
+      const t0 = performance.now();
+      const loop = (t: number) => {
+        (program.uniforms.iTime as { value: number }).value = (t - t0) * 0.001;
+        renderer?.render({ scene: mesh });
+        raf = requestAnimationFrame(loop);
+      };
+      raf = requestAnimationFrame(loop);
+      setIsWebglAvailable(true);
+    } catch {
+      // Revert to the previous plain hero look if WebGL2 is unavailable.
+      setIsWebglAvailable(false);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro?.disconnect();
+      if (canvas) {
+        try {
+          container.removeChild(canvas);
+        } catch {
+          // Ignore
+        }
+      }
+    };
+  }, [
+    timeSpeed,
+    colorBalance,
+    warpStrength,
+    warpFrequency,
+    warpSpeed,
+    warpAmplitude,
+    blendAngle,
+    blendSoftness,
+    rotationAmount,
+    noiseScale,
+    grainAmount,
+    grainScale,
+    grainAnimated,
+    contrast,
+    gamma,
+    saturation,
+    centerX,
+    centerY,
+    zoom,
+    resolvedColor1,
+    resolvedColor2,
+    color3,
+  ]);
+
+  if (!isWebglAvailable) {
+    return null;
+  }
+
+  return (
+    <div ref={containerRef} className={`relative h-full w-full overflow-hidden ${className}`.trim()}>
+      {overlayClassName && (
+        <div className={`pointer-events-none absolute inset-0 ${overlayClassName}`.trim()} />
+      )}
+    </div>
+  );
+};
+
+export default Grainient;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import Card from '../components/ui/Card.astro';
 import Button from '../components/ui/Button.astro';
 import Tag from '../components/ui/Tag.astro';
 import OptimizedImage from '../components/ui/OptimizedImage.astro';
+import Grainient from '../components/ui/Grainient';
 import { SITE, SOCIAL_LINKS } from '../config/site';
 
 // Fetch latest blog posts (limit to 3)
@@ -59,8 +60,39 @@ const typeLabel: Record<string, string> = {
   />
 
   <!-- Hero Section -->
-  <Section spacing="none" class="min-h-[75svh] flex items-center">
-    <Container size="lg">
+  <Section spacing="none" class="relative min-h-screen md:-mt-24 md:pt-24 flex items-center overflow-hidden">
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <Grainient
+        client:load
+        color1="var(--color-brand-200-hex)"
+        darkColor1="var(--color-brand-700-hex)"
+        color2="var(--color-brand-500-hex)"
+        darkColor2="var(--color-brand-800-hex)"
+        color3="var(--color-accent-400-hex)"
+        timeSpeed={1.0}
+        colorBalance={0.0}
+        warpStrength={1.0}
+        warpFrequency={5.0}
+        warpSpeed={2.0}
+        warpAmplitude={50.0}
+        blendAngle={0.0}
+        blendSoftness={0.05}
+        rotationAmount={500.0}
+        noiseScale={2.0}
+        grainAmount={0.1}
+        grainScale={2.0}
+        grainAnimated={true}
+        contrast={1.5}
+        gamma={1.0}
+        saturation={1.0}
+        centerX={0.0}
+        centerY={0.0}
+        zoom={1.75}
+        overlayClassName="bg-bg-base/18 dark:bg-bg-base/24"
+      />
+    </div>
+
+    <Container size="lg" class="relative z-10">
       <div class="max-w-4xl mx-auto text-center">
         <h1 class="text-7xl font-bold leading-tight mb-m text-text-primary">
           Hi,<br class="md:hidden"> I'm Jet Sanchez.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,16 @@
     --color-brand-subtle: oklch(0.8895 0.0164 245.1);    /* brand.3 */
     --color-brand-text: oklch(0.384 0.0392 251.63);      /* brand.9 */
     --color-brand-contrast: oklch(1 0 0);                /* White */
+    --color-brand-200: oklch(0.9502 0.0069 247.9);       /* brand.2 */
+    --color-brand-500: oklch(0.6728 0.0512 244.82);      /* brand.5 */
+    --color-brand-700: oklch(0.4956 0.0566 248.16);      /* brand.7 */
+    --color-brand-800: oklch(0.4296 0.0477 248.99);      /* brand.8 */
+    /* Shader-only HEX aliases: keep in lockstep with matching OKLCH tokens above. */
+    /* If brand/accent scales change, update both representations together. */
+    --color-brand-200-hex: #ebeff3;                      /* brand.2 */
+    --color-brand-500-hex: #7c9ab4;                      /* brand.5 */
+    --color-brand-700-hex: #486581;                      /* brand.7 */
+    --color-brand-800-hex: #3b5269;                      /* brand.8 */
 
     /* Accent */
     --color-accent-base: oklch(0.8005 0.1639 84.11);     /* accent.6 */
@@ -42,6 +52,8 @@
     --color-accent-subtle: oklch(0.9455 0.1274 101.26);  /* accent.3 */
     --color-accent-text: oklch(0.4766 0.1078 59.07);     /* accent.9 */
     --color-accent-contrast: oklch(0.2852 0.0664 52.21);  /* accent.11 — deep brown */
+    --color-accent-400: oklch(0.9068 0.1681 97.52);      /* accent.4 */
+    --color-accent-400-hex: #ffe043;                     /* accent.4 */
 
     /* === UTOPIA FLUID TYPOGRAPHY === */
     /* @link https://utopia.fyi/type/calculator?c=320,16,1.125,1440,17,1.2,7,2,&s=0.75|0.5|0.25|0.25|0.25,1.5|2|3|4|6|6|6,s-l&g=s,l,xl,12 */


### PR DESCRIPTION
Implemented a full-viewport Grainient hero background for the homepage, aligned with the design system and resilient to browser capability differences.

- Added new Grainient WebGL component using ogl for animated shader rendering
- Integrated Grainient into the homepage hero and extended it behind the dock area
- Applied theme-aware shader palette:
- Light mode uses brand 200/500 with accent 400
- Dark mode uses brand 700/800 with accent 400
- Switched hero shader color inputs to CSS token-backed variables
- Added shader-safe HEX token aliases with lockstep maintenance notes
- Added graceful fallback to the previous plain hero look when WebGL2 is unavailable
- Kept readability layer in-component via configurable overlayClassName
- Verified with astro check and build:site on latest origin/main