### PR TITLE
fix(api): Restrict chat endpoint to same-origin traffic

### DIFF
--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -12,6 +12,7 @@
  */
 
 import type { APIRoute } from 'astro';
+import { SITE } from '../../config/site';
 
 // Mark this endpoint as server-rendered (not static)
 export const prerender = false;
@@ -31,7 +32,7 @@ interface ChatRequest {
 /**
  * POST /api/chat - Generate streaming response from retrieved context
  */
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, clientAddress }) => {
   try {
     const { query, context } = (await request.json()) as ChatRequest;
 
@@ -40,9 +41,13 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response('Missing query or context', { status: 400 });
     }
 
+    // Enforce same-origin requests to prevent unauthenticated third-party abuse
+    if (!isAllowedOrigin(request)) {
+      return new Response('Forbidden', { status: 403 });
+    }
+
     // Rate limiting (best-effort)
-    const ip = request.headers.get('x-forwarded-for') || 'unknown';
-    if (await isRateLimited(ip)) {
+    if (await isRateLimited(clientAddress)) {
       return new Response('Rate limit exceeded. Please try again in a minute.', {
         status: 429,
       });
@@ -253,6 +258,28 @@ function parseOpenRouterSSE(stream: ReadableStream<Uint8Array>): ReadableStream 
       }
     },
   });
+}
+
+
+function getAllowedOrigins(request: Request): Set<string> {
+  const allowedFromEnv = import.meta.env.CHAT_ALLOWED_ORIGINS
+    ?.split(',')
+    .map((origin: string) => origin.trim())
+    .filter(Boolean) ?? [];
+
+  const requestOrigin = new URL(request.url).origin;
+
+  return new Set([SITE.siteUrl, requestOrigin, ...allowedFromEnv]);
+}
+
+function isAllowedOrigin(request: Request): boolean {
+  const origin = request.headers.get('origin');
+
+  if (!origin) {
+    return false;
+  }
+
+  return getAllowedOrigins(request).has(origin);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- The public `POST /api/chat` endpoint proxied requests to OpenRouter using a server API key with only a spoofable, header-based rate limiter, enabling unauthenticated third-party abuse and denial-of-wallet risks.
- The change aims to stop external sites from directly triggering server-side LLM calls while preserving the in-site chatbot UX.

### Description
- Enforce origin allowlist for `POST /api/chat` by adding `isAllowedOrigin(request)` which rejects non-allowed `Origin` headers with `403` before any OpenRouter call is made.
- Add `getAllowedOrigins` that accepts the site URL, the request origin, and optional extra entries from the `CHAT_ALLOWED_ORIGINS` environment variable (comma-separated).
- Switch rate-limit keying from the client-supplied `x-forwarded-for` header to Astro's `clientAddress` parameter to reduce spoofability for the existing best-effort limiter.
- Import `SITE` from site config and make the above changes in `src/pages/api/chat.ts` to perform checks prior to invoking the OpenRouter API.

### Testing
- Attempted `npm run astro check` in the runner; the command failed because `astro` is not installed in this environment (`sh: 1: astro: not found`).
- No other automated tests were available or executed in this environment; changes were validated by static inspection and a local commit that updated `src/pages/api/chat.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e05824b2188328830ae757b6a086c8)