### PR TITLE
fix(content): feature telemetry study

### DIFF
--- a/src/data/works/broad-reach-uneven-depth.mdx
+++ b/src/data/works/broad-reach-uneven-depth.mdx
@@ -26,3 +26,11 @@ links:
 ## Abstract
 
 Claims about national artificial-intelligence adoption increasingly rely on corporate telemetry, even though the available systems count different phenomena. This paper compares the Philippines across Microsoft AI Diffusion, OpenAI Signals, and the Anthropic Economic Index. Microsoft estimates the share of working-age people reaching any of 19 covered generative-AI products; OpenAI reports a population-normalized rank based on consumer ChatGPT messages; Anthropic reports Claude conversation activity and composition. We align early-2026 observations, hold the Philippines out of cross-country regressions, and express its prediction error as a leave-one-country-out residual percentile under common development, access, services, education, and service-export covariates. The three systems strongly agree on the international ordering of countries, with pairwise Spearman correlations of 0.83–0.88 in the harmonized sample. They do not agree that the Philippines is an outlier. Microsoft's modeled AI User Share is 20.1 percent, compared with a structurally predicted 15.2 percent in the core model, placing the Philippine residual at the 82nd percentile. OpenAI places it at the 65th residual percentile, while population-normalized Claude activity is near the middle of the residual distribution. Growth in Microsoft's estimate is also close to the cross-country median. The evidence therefore does not establish a robust national adoption premium. It instead shows that Philippine standing changes materially with the telemetry construct, motivating direct household, worker, and firm measurement.
+
+## Citation
+
+```
+Sanchez, J. E. M. (2026). Broad Reach, Uneven Depth? Reconciling Philippine
+Generative-AI Diffusion Across Three Telemetry Systems. SSRN Working Paper.
+https://dx.doi.org/10.2139/ssrn.7146398
+```

--- a/src/data/works/broad-reach-uneven-depth.mdx
+++ b/src/data/works/broad-reach-uneven-depth.mdx
@@ -10,7 +10,7 @@ date: "2026-07"
 tags: ["generative AI", "AI adoption", "technology diffusion", "platform telemetry", "Philippines", "cross-country measurement"]
 status: published
 assistant: true
-featured: false
+featured: true
 image:
   url: "https://vyge4wbmw8jgd8rh.public.blob.vercel-storage.com/images/works/broad-reach-uneven-depth-2f36bce5.webp"
   alt: "A luminous network stretching across a dark landscape with bright streams descending to uneven depths"

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1277,6 +1277,10 @@ test('the telemetry study is published across discovery, schema, and assistant s
   await expect(
     page.getByRole('link', { name: 'View on SSRN' }),
   ).toHaveAttribute('href', doi);
+  await expect(page.getByRole('heading', { name: 'Citation' })).toBeVisible();
+  await expect(page.locator('pre code')).toContainText(
+    'Sanchez, J. E. M. (2026). Broad Reach, Uneven Depth?',
+  );
   const schemas = await readSchemas(page);
   expect(
     schemas.find((schema) => schema['@type'] === 'ScholarlyArticle'),

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1263,7 +1263,7 @@ test('the telemetry study is published across discovery, schema, and assistant s
   };
 
   expect(route.status()).toBe(200);
-  expect(home).not.toContain(slug);
+  expect(home).toContain(slug);
   expect(works).toContain(slug);
   expect(sitemap).toContain(canonical);
   expect(corpus.documents).toContainEqual(


### PR DESCRIPTION
## Summary
- feature the newly published telemetry study on the homepage
- make the existing discovery test protect that public placement

## Verification
- `npm run verify`
- `npm run verify:browser -- tests/e2e/site.spec.ts -g "telemetry study is published"`