### PR TITLE
fix(content): correct telemetry publication date

### DIFF
--- a/src/data/works/broad-reach-uneven-depth.mdx
+++ b/src/data/works/broad-reach-uneven-depth.mdx
@@ -6,7 +6,7 @@ seoDescription: "A cross-platform measurement audit finding that Philippine gene
 description: "A cross-platform measurement audit finding that Philippine generative-AI standing changes materially across Microsoft, OpenAI, and Anthropic telemetry."
 summary: "A cross-platform audit showing how Philippine generative-AI standing shifts across three telemetry systems."
 type: "research"
-date: "2026-07"
+date: "2026-08-01"
 tags: ["generative AI", "AI adoption", "technology diffusion", "platform telemetry", "Philippines", "cross-country measurement"]
 status: published
 assistant: true

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1275,6 +1275,9 @@ test('the telemetry study is published across discovery, schema, and assistant s
 
   await page.goto(`/works/${slug}/`);
   await expect(
+    page.locator('time[datetime="2026-08-01T00:00:00.000Z"]'),
+  ).toHaveText('August 2026');
+  await expect(
     page.getByRole('link', { name: 'View on SSRN' }),
   ).toHaveAttribute('href', doi);
   await expect(page.getByRole('heading', { name: 'Citation' })).toBeVisible();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -329,17 +329,17 @@ test('homepage content cards include their padded perimeter in the dominant acti
 }) => {
   await page.goto('/');
 
-  const primaryAction = page.locator(
-    'main a[href="/works/digital-squad-timesheet/"]',
-  );
-  await primaryAction.scrollIntoViewIfNeeded();
-  const card = primaryAction.locator('..');
+  const card = page.locator('main [data-content-card="true"]').first();
+  const primaryAction = card.locator(':scope > a');
+  const destination = await primaryAction.getAttribute('href');
+  if (!destination) throw new Error('Missing homepage card destination');
+
+  await card.scrollIntoViewIfNeeded();
   const cardBounds = await card.boundingBox();
-  if (!cardBounds)
-    throw new Error('Missing Digital Squad Timesheet homepage card');
+  if (!cardBounds) throw new Error('Missing homepage content card');
 
   await page.mouse.click(cardBounds.x + 4, cardBounds.y + 4);
-  await expect(page).toHaveURL('/works/digital-squad-timesheet/');
+  await expect(page).toHaveURL(destination);
 });
 
 test('homepage content cards use deliberate human-facing card copy', async ({


### PR DESCRIPTION
## Summary
- correct the telemetry study publication date to August 1, 2026
- verify the exact semantic date while preserving the Works month-year presentation

## Verification
- `npm run verify`
- `npm run verify:browser -- tests/e2e/site.spec.ts -g "telemetry study is published"`