### PR TITLE
fix(content): normalize tag labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ assistant: false
 - Blog fields include title, optional short display title, description, optional card summary, optional search title and description overrides, publication date, author, tags, publication state, assistant eligibility, optional image metadata, and optional explicit review metadata.
 - Review metadata currently identifies a movie and an integer rating on the five-star scale. It renders in the article header and as a linked `Review` JSON-LD entity; Blog and Home cards remain unrated editorial teasers.
 - Work fields include title, optional short display title, description, optional card summary, optional search title and description overrides, type, date, tags, publication state, assistant eligibility, optional featured/image/link fields, and type-specific research or project fields.
+- Tags are human-facing labels rendered verbatim. Separate words with spaces rather than kebab-case hyphens; retain hyphens only when the term itself requires one, such as `Spider-Man` or `cross-country measurement`.
 - Every content image requires a stable URL and descriptive `alt` text. Blog images also record their verified intrinsic pixel `width` and `height` so custom OpenGraph metadata never borrows false default dimensions.
 - Run `npm run verify:content` after changing frontmatter or content-policy code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jet-web",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jet-web",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "@astrojs/mdx": "7.0.3",
         "@astrojs/partytown": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jet-web",
   "type": "module",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "engines": {
     "node": "24.x"
   },

--- a/src/data/blog/how-to-install-claude-code-cli-2026.mdx
+++ b/src/data/blog/how-to-install-claude-code-cli-2026.mdx
@@ -8,7 +8,7 @@ summary: "Install Claude Code CLI, configure plugins and skills, and start using
 pubDate: 2026-01-13
 updatedDate: 2026-01-18
 author: "Jet Sanchez"
-tags: ["claude-code", "AI", "dev-tools", "CLI", "tutorial", "anthropic"]
+tags: ["Claude Code", "AI", "developer tools", "CLI", "tutorial", "Anthropic"]
 status: published
 assistant: true
 image:

--- a/src/data/blog/spider-man-brand-new-day.mdx
+++ b/src/data/blog/spider-man-brand-new-day.mdx
@@ -8,7 +8,7 @@ summary: "Spider-Man: Brand New Day completes Peter Parker’s metamorphosis by 
 pubDate: 2026-08-01
 updatedDate: 2026-08-10
 author: "Jet Sanchez"
-tags: ["film", "film-reviews", "Spider-Man", "Marvel", "MCU"]
+tags: ["film", "film reviews", "Spider-Man", "Marvel", "MCU"]
 status: published
 assistant: true
 review:

--- a/src/data/blog/vibe-coding-vs-agentic-coding-why-the-distinction-matters.mdx
+++ b/src/data/blog/vibe-coding-vs-agentic-coding-why-the-distinction-matters.mdx
@@ -10,10 +10,10 @@ updatedDate: 2026-01-18
 author: 'Jet Sanchez'
 tags:
   - AI
-  - dev-tools
-  - vibe-coding
-  - agentic-coding
-  - claude-code
+  - developer tools
+  - vibe coding
+  - agentic coding
+  - Claude Code
 status: published
 assistant: true
 image:

--- a/src/data/works/broad-reach-uneven-depth.mdx
+++ b/src/data/works/broad-reach-uneven-depth.mdx
@@ -7,7 +7,7 @@ description: "A cross-platform measurement audit finding that Philippine generat
 summary: "A cross-platform audit showing how Philippine generative-AI standing shifts across three telemetry systems."
 type: "research"
 date: "2026-08-01"
-tags: ["generative-AI", "AI-adoption", "technology-diffusion", "platform-telemetry", "Philippines", "cross-country measurement"]
+tags: ["generative AI", "AI adoption", "technology diffusion", "platform telemetry", "Philippines", "cross-country measurement"]
 status: published
 assistant: true
 featured: true

--- a/src/data/works/digital-squad-timesheet.mdx
+++ b/src/data/works/digital-squad-timesheet.mdx
@@ -6,7 +6,7 @@ description: "A task-based weekly operations platform for Digital Squad, combini
 summary: "A weekly operations platform for time logging, project context, team visibility, and reporting."
 type: "project"
 date: 2026-07-18
-tags: ["product-design", "operations", "Next.js", "TypeScript", "PostgreSQL", "Supabase", "Playwright"]
+tags: ["product design", "operations", "Next.js", "TypeScript", "PostgreSQL", "Supabase", "Playwright"]
 status: published
 assistant: true
 featured: true

--- a/src/data/works/recursive-convergence-hypothesis.mdx
+++ b/src/data/works/recursive-convergence-hypothesis.mdx
@@ -7,7 +7,7 @@ description: "A theoretical framework proposing that recursive artificial superi
 summary: "A framework for how ASI may converge on synthetic sentience through recursive self-improvement."
 type: "research"
 date: 2025-08-27
-tags: ["AI", "AGI", "ASI", "consciousness", "sentience", "AI-safety", "recursive-systems", "emergent-phenomena", "machine-consciousness", "AI-governance", "phenomenology"]
+tags: ["AI", "AGI", "ASI", "consciousness", "sentience", "AI safety", "recursive systems", "emergent phenomena", "machine consciousness", "AI governance", "phenomenology"]
 status: published
 assistant: true
 featured: true


### PR DESCRIPTION
## Summary

- normalize Blog and Works tags to human-facing labels with spaces rather than kebab-case separators
- preserve grammatical and proper-name hyphens such as Spider-Man and cross-country measurement
- document the convention and bump jet-web to 2.2.2

## Verification

- `npm run verify` — 555 passed
- `npm run verify:browser` — 253 passed, 19 intentional skips
- `npm run verify:build-purity`
- independent review — approved with no findings