### PR TITLE
feat(blog): publish EU AI Act essay

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   outputDir: 'test-results/playwright',
   fullyParallel: false,
+  workers: process.env.CI ? 2 : 3,
   forbidOnly: Boolean(process.env.CI),
   failOnFlakyTests: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,

--- a/src/data/blog/eu-ai-act-regulating-technology-no-longer-exists.mdx
+++ b/src/data/blog/eu-ai-act-regulating-technology-no-longer-exists.mdx
@@ -1,0 +1,208 @@
+---
+title: "The EU AI Act Is Regulating Technology That No Longer Exists"
+shortTitle: "The EU AI Act Is Regulating Tech That No Longer Exists"
+seoTitle: "The EU AI Act Is Regulating Tech That No Longer Exists"
+seoDescription: "The EU AI Act’s AI-content rules mistake machine provenance for meaningful authorship and regulate a delayed image of frontier AI."
+description: "The EU AI Act’s AI-content rules mistake machine provenance for meaningful authorship and regulate a delayed image of frontier AI."
+summary: "The EU AI Act is trying to watermark the future by regulating a delayed image of frontier AI."
+pubDate: 2026-08-12
+author: "Jet Sanchez"
+tags: ["AI", "AI governance", "EU AI Act", "technology regulation", "Anthropic", "watermarking"]
+status: published
+assistant: true
+image:
+  url: "https://vyge4wbmw8jgd8rh.public.blob.vercel-storage.com/images/blog/eu-ai-act-regulating-technology-no-longer-exists-2ea9ebb2.jpg"
+  alt: "A surreal collage of a hand holding a globe encircled by European Union stars"
+  width: 1920
+  height: 1080
+---
+
+Perhaps the most revealing thing about the EU AI Act today is that it regulates an idea of artificial intelligence that is already obsolete.
+
+Article 50 is a perfect example. Its underlying model of the world is simple: humans make human things, AI makes AI things, and therefore AI things should carry some persistent signal identifying them as such.
+
+That framework might have sounded coherent in 2023. But in 2026, it is almost embarrassingly primitive.
+
+Modern knowledge work is already becoming an entangled system of humans, models, agents, retrieval systems, code execution, search, automation, evaluation loops, proprietary data, human judgment and machine-generated intermediate artifacts.
+
+There is increasingly no clean boundary at which something becomes “AI-generated.” There’s a production process. There are degrees of contribution. There are transformations. There’s direction, supervision, verification and responsibility.
+
+And yet Brussels has decided that one of the important facts worth preserving about an artifact is whether an AI touched it.
+
+That is far removed from sophisticated AI governance.
+
+## Anthropic’s Folly
+
+Anthropic’s implementation of AI-content marking makes the problem unusually concrete.
+
+The company is [introducing machine-detectable provenance into Claude-generated text](https://support.claude.com/en/articles/16266773-how-claude-marks-ai-generated-content) in response to European transparency requirements. Unlike metadata attached to a file, a text watermark can require intervention in the actual generation process. Depending on the implementation, token selection can be statistically biased or otherwise coupled to a watermarking scheme so that the resulting sequence contains a detectable signal.
+
+Think about what that means.
+
+The system is no longer optimizing only for your request and the model’s learned distribution. A third objective has entered the inference process:
+
+Produce a useful answer, but produce it in a way that leaves behind evidence that Anthropic was here.
+
+That means if token selection changes, the generated sequence can change. In an autoregressive model, changing one token changes the context for every token that follows. The intervention may be imperceptible to the user, but that doesn’t make it nonexistent.
+
+“Imperceptible” is not a synonym for “causally inert.” And if Anthropic has globally deployed this architecture to simplify compliance with European rules, then somebody using [Claude Code](/blog/how-to-install-claude-code-cli-2026/) in Manila can have Claude’s inference behavior altered because regulators in Brussels decided synthetic content needed machine-readable provenance.
+
+That’s an extraordinary extraterritorial consequence for a rule supposedly concerned with transparency.
+
+## Who Owns the Work?
+
+The inference issue is bad enough. The provenance issue is worse.
+
+Suppose I write a blog post.
+
+I determine the thesis. I conduct the research. I supply my notes. I decide what evidence matters. I instruct an agent to challenge the argument. I reject several drafts. I rewrite half of it myself. I ask a model to tighten two sections, restructure one paragraph and clean the grammar.
+
+Whose work is it?
+
+In any intellectually serious account of authorship, the answer cannot be determined by counting keystrokes. Yet a persistent AI watermark introduces another answer entirely: whatever else this document is, it is machine-detectable as having passed through Anthropic.
+
+Why?
+
+Why should Anthropic retain a durable provenance relationship with my work after its model has acted as my tool?
+
+Microsoft Word doesn’t secretly manipulate my word choice so Microsoft can later determine that Word participated in the document. A compiler doesn’t embed a statistical signature into the logic of my software to prove that GCC was involved. A calculator doesn’t preserve a manufacturer-level claim over the arithmetic I perform with it.
+
+But apparently an AI model should.
+
+And the implication becomes particularly absurd with agents.
+
+If I design the agent architecture, choose the model, provide the context, select the tools, define the evaluation criteria, supervise the work, interrogate the conclusions, verify the evidence and take responsibility for the resulting artifact, the meaningful question isn’t whether some token inside the final document originated from a language model.
+
+The meaningful questions become whether the work is correct, whether the evidence is traceable, whether the reasoning survives scrutiny and whether I am willing to stand behind it.
+
+A watermark throws all of that nuance away in favor of the least interesting fact imaginable:
+
+Claude touched this.
+
+## J’Accuse...!
+
+The obvious social consequence isn’t that hard to predict.
+
+“You used AI for this.”
+
+That sentence is going to be treated as if it establishes far more than it actually does.
+
+A machine-detectable signal may establish that an AI system interacted with a piece of text somewhere in its production history, but it doesn’t tell you whether the person authored the argument themselves. It doesn’t tell you whether the AI contributed one comma or forty paragraphs. It doesn’t tell you whether the model performed proofreading, translation, research assistance, structural editing, summarization or substantive authorship.
+
+But institutions aren’t famous for preserving distinctions once a binary detector exists.
+
+The watermark says AI involvement. The professor hears AI cheating. The employer hears AI-generated work. The client hears outsourced thinking. The internet hears fraud.
+
+A complicated chain of human-machine collaboration collapses into a scarlet letter generated by the vendor’s own infrastructure.
+
+And this is supposed to increase trust?
+
+## The Wrong Question
+
+The entire framework is based on a question that is rapidly losing usefulness.
+
+Was AI used?
+
+Soon the answer to that question in serious knowledge work will be approximately: obviously.
+
+AI will be used to retrieve information, inspect datasets, challenge assumptions, execute code, locate contradictions, summarize meetings, generate tests, critique drafts, normalize formatting, analyze documents, search the web, compare evidence and operate software.
+
+The divide won’t be AI versus human.
+
+It’ll be competent versus incompetent. Verified versus unverified. Original versus derivative. Accountable versus unaccountable. Traceable versus fabricated.
+
+A person who delegates research to an agent but meticulously verifies every source may produce more trustworthy work than somebody who manually searches Google for three hours and misunderstands half of what they read.
+
+A researcher who uses models aggressively but retains epistemic control may be exercising more intellectual judgment than somebody who performs every mechanical step by hand.
+
+Tool use isn’t authorship. Tool avoidance isn’t integrity. And manual labor isn’t epistemic virtue.
+
+The fixation on detecting whether AI participated in a document belongs to a transitional period in which society still imagines intelligence as something that either happened inside one human skull or was “generated by AI.”
+
+That world is already disappearing.
+
+## The EU AI Act Is Perpetually Behind
+
+This is the larger failure.
+
+The AI Act went through years of proposal, negotiation, compromise and implementation. That is normal for legislation. It is also catastrophically slow relative to the technology being regulated.
+
+AI development moves in months, but regulation moves in years.
+
+By the time a regulatory concept becomes enforceable, the frontier may have gone through several architectural generations.
+
+The result is predictable: policymakers regulate yesterday’s technology using yesterday’s vocabulary, and vendors are then required to engineer tomorrow’s systems around those assumptions.
+
+“AI-generated content” is a particularly revealing fossil. The phrase assumes an artifact with a clear origin event: a human made it, or an AI made it.
+
+But increasingly there is no origin event.
+
+There’s an [agentic production graph](/blog/vibe-coding-vs-agentic-coding-why-the-distinction-matters/).
+
+One model retrieves information. Another analyzes it. Code transforms the data. A human supplies constraints. An agent generates a draft. Another agent criticizes it. The human rewrites the conclusion. A model checks citations. A publishing system converts the final artifact into several formats.
+
+Which part is the “AI-generated content”?
+
+The paragraph? The sentence? The research? The structure? The dataset transformation? The entire output?
+
+The question is malformed. Yet the regulatory response is to make the supposed answer machine-detectable.
+
+This is what happens when law trails the technological frontier by an entire paradigm.
+
+## Regulation Should Target Harms
+
+There are perfectly legitimate things to regulate.
+
+Fraud, impersonation, malicious deepfakes, and fabricated evidence should all be regulated. High-stakes automated decisions should have appropriate accountability. Political ads can reasonably carry transparency requirements. Misrepresenting synthetic media as authentic evidence can cause obvious harm.
+
+But none of those principles require declaring that every ordinary interaction with generative systems should leave behind a persistent machine-readable provenance signal.
+
+That’s the stark difference between regulating an outcome and regulating an architecture.
+
+Outcome-oriented rules can survive technological change.
+
+Do not defraud people. Do not impersonate somebody deceptively. Disclose material synthetic alteration where authenticity is itself relevant. Remain accountable for decisions in high-stakes domains.
+
+Those concepts still make sense if models become agents, agents become operating environments, and human-machine collaboration becomes the default form of knowledge work.
+
+But “make AI-generated content detectable” depends on an assumption that AI-generated content remains a coherent category.
+
+It may not.
+
+## The Darkest Timeline
+
+And now consider the incentives.
+
+If one AI provider places a persistent machine-detectable signature into your work and another doesn’t, people who care about control over their artifacts have an obvious reason to choose the second provider.
+
+Not necessarily because they’re trying to cheat or pass AI homework off as their own, but because they don’t want a technology vendor asserting permanent provenance over their work.
+
+Researchers, writers, consultants, lawyers, developers, and companies will all care.
+
+Some users will move to local models. Others will introduce transformations that destroy the watermark. Others will avoid the vendor entirely.
+
+Congratulations: a regulation designed to create trustworthy provenance may create a competitive market for unmarked inference.
+
+The people who care most about provenance may become the people most motivated to route around the provenance system.
+
+Brilliant.
+
+## This Is Not Serious Governance of Frontier AI
+
+Transparency is an admirable end.
+
+The problem is that the EU has mistaken a simplistic technical intervention for sophisticated governance.
+
+AI is no longer just a machine that produces content on command. Increasingly, it’s infrastructure for cognition itself: a participant in research, analysis, software development, planning, communication and decision-making.
+
+Regulating that world requires an understanding of systems, workflows, responsibility and epistemology.
+
+Instead, we get invisible marks in text.
+
+A regulatory regime devised around the anxieties of early generative AI is now being embedded into the architecture of systems several generations removed from the technology policymakers were originally contemplating.
+
+And because legislation moves so much more slowly than the frontier, the gap doesn’t close. It compounds.
+
+Bureaucrats are trying to watermark the future under the guise of governing frontier AI.
+
+But what they’re actually doing is governing a delayed image of frontier AI, while everyone else is forced to deal with the consequences.

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -193,6 +193,7 @@ for (const theme of ['light', 'dark'] as const) {
     request,
   }, testInfo) => {
     test.skip(testInfo.project.name !== 'chromium');
+    test.slow();
 
     await page.addInitScript((selectedTheme) => {
       localStorage.setItem('theme', selectedTheme);
@@ -263,10 +264,16 @@ test('Egregore introduction, ready, and response states remain accessible by key
   await expect(composer).toBeFocused();
   await expect(composer).toHaveValue(suggestedQuestions[0]);
 
+  await page.clock.install();
+  const pageNow = await page.evaluate(() => Date.now());
+  await page.clock.pauseAt(pageNow + 1_000);
   const send = page.getByRole('button', { name: 'Send message' });
   await focusWithKeyboard(page, send);
   await page.keyboard.press('Enter');
   await expectLifecycleAccessibility(page, 'Egregore is responding.');
+  await page.clock.runFor(1_000);
+  await expectLifecycleAccessibility(page, 'Egregore is ready.');
+  await page.clock.resume();
 
   const conversation = page.getByLabel('Conversation');
   const response = conversation.locator('article').last().locator('p').first();

--- a/tests/e2e/egregore.spec.ts
+++ b/tests/e2e/egregore.spec.ts
@@ -283,29 +283,52 @@ async function startFakeAssistant(
   return composer;
 }
 
+async function generatedResponseCount(page: Page): Promise<number> {
+  return (await runtimeMethods(page)).filter((method) => method === 'generate')
+    .length;
+}
+
 async function submitQuestion(
   page: Page,
   question: string,
   modality: 'pointer' | 'keyboard' = 'pointer',
-): Promise<void> {
+): Promise<number> {
+  const completedGenerationCount = await generatedResponseCount(page);
   const composer = page.getByRole('textbox', { name: 'Ask Egregore' });
   await composer.fill(question);
   if (modality === 'keyboard') await composer.press('Enter');
   else await page.getByRole('button', { name: 'Send message' }).click();
+  return completedGenerationCount;
 }
 
-async function waitForCompletedResponse(page: Page): Promise<void> {
+async function waitForCompletedResponse(
+  page: Page,
+  completedGenerationCount: number,
+): Promise<void> {
   await expect
     .poll(
       async () =>
         (await runtimeMethods(page)).filter((method) => method === 'generate')
           .length,
     )
-    .toBeGreaterThan(0);
+    .toBeGreaterThan(completedGenerationCount);
   await expect(
     page.getByRole('textbox', { name: 'Ask Egregore' }),
   ).toBeEnabled();
   await expect(currentStatusLabel(page)).toHaveText('Ready');
+}
+
+async function submitQuestionAndWait(
+  page: Page,
+  question: string,
+  modality: 'pointer' | 'keyboard' = 'pointer',
+): Promise<void> {
+  const completedGenerationCount = await submitQuestion(
+    page,
+    question,
+    modality,
+  );
+  await waitForCompletedResponse(page, completedGenerationCount);
 }
 
 async function boxOf(locator: Locator): Promise<Box> {
@@ -620,8 +643,7 @@ test.describe('Egregore consent and local privacy', () => {
       page.getByRole('button', { name: 'Remove downloaded model' }),
     ).toHaveCount(0);
 
-    await submitQuestion(page, PROMPT_SENTINEL);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, PROMPT_SENTINEL);
 
     const fetches = await auditedFetches(page);
     const corpusFetches = fetches.filter(({ url }) =>
@@ -887,8 +909,10 @@ test.describe('Egregore compact navigation clearance', () => {
     );
 
     const tabletComposer = await startFakeAssistant(page);
-    await submitQuestion(page, 'What does Jet write about agentic work?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      'What does Jet write about agentic work?',
+    );
     const [tabletComposerBox, tabletScrollerBox] = await Promise.all([
       boxOf(tabletComposer),
       boxOf(page.getByTestId('conversation-scroller')),
@@ -905,8 +929,10 @@ test.describe('Egregore compact navigation clearance', () => {
     const desktopDock = page.locator('#site-navigation-dock');
     const desktopHeaderContent = page.getByTestId('egregore-identity');
     const desktopComposer = await startFakeAssistant(page);
-    await submitQuestion(page, 'What does Jet write about agentic work?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      'What does Jet write about agentic work?',
+    );
     const [
       desktopDockBox,
       desktopHeaderBox,
@@ -1079,13 +1105,14 @@ test.describe('Egregore supported lifecycle', () => {
     await expect(composer).toBeFocused();
     await expect(composer).toHaveValue(question);
 
+    const completedGenerationCount = await generatedResponseCount(page);
     await page.getByRole('button', { name: 'Send message' }).click();
     await expect(composer).not.toBeFocused();
     await expect(reliability).toHaveCount(0);
     await expect(
       page.getByRole('button', { name: 'Stop response' }),
     ).toBeVisible();
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
 
     const inlineCitation = page
       .getByRole('link', { name: /\[S\d+\]/u })
@@ -1211,6 +1238,7 @@ test.describe('Egregore supported lifecycle', () => {
     ).toHaveCount(0);
 
     await composer.fill('Summarize the recursive convergence hypothesis.');
+    const completedGenerationCount = await generatedResponseCount(page);
     await page.getByRole('button', { name: 'Send message' }).click();
     await expect(currentStatusLabel(page)).toHaveText('Responding');
     const respondingImmediate = {
@@ -1253,7 +1281,7 @@ test.describe('Egregore supported lifecycle', () => {
     const statusLabels = page.getByTestId('lifecycle-visual-label');
     expect(await statusLabels.count()).toBeLessThanOrEqual(2);
     await page.clock.runFor(1_000);
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
     await expect(newSession).toBeEnabled();
     await expect(unload).toBeEnabled();
 
@@ -1307,9 +1335,10 @@ test.describe('Egregore supported lifecycle', () => {
   }, testInfo) => {
     const composer = await startFakeAssistant(page, 'long-stream');
     await composer.fill('What does Jet write about agentic work?');
+    const completedGenerationCount = await generatedResponseCount(page);
     await page.getByRole('button', { name: 'Send message' }).click();
     await expect(composer).not.toBeFocused();
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
     await expect(composer).not.toBeFocused();
 
     await page
@@ -1324,16 +1353,18 @@ test.describe('Egregore supported lifecycle', () => {
         composerBox.y + composerBox.height / 2,
       );
       await composer.fill('Summarize the recursive convergence hypothesis.');
+      const touchGenerationCount = await generatedResponseCount(page);
       await composer.press('Enter');
       await expect(composer).not.toBeFocused();
-      await waitForCompletedResponse(page);
+      await waitForCompletedResponse(page, touchGenerationCount);
       await expect(composer).not.toBeFocused();
     } else {
       await composer.focus();
       await composer.fill('Summarize the recursive convergence hypothesis.');
+      const keyboardGenerationCount = await generatedResponseCount(page);
       await composer.press('Enter');
       await expect(composer).toBeFocused();
-      await waitForCompletedResponse(page);
+      await waitForCompletedResponse(page, keyboardGenerationCount);
       await expect(composer).toBeFocused();
       const newSession = page.getByRole('button', { name: 'New session' });
       await newSession.focus();
@@ -1348,9 +1379,12 @@ test.describe('Egregore supported lifecycle', () => {
   }) => {
     await installLifecycleLabelAudit(page);
     const composer = await startFakeAssistant(page, 'long-stream');
-    await submitQuestion(page, 'What does Jet write about agentic work?');
+    const completedGenerationCount = await submitQuestion(
+      page,
+      'What does Jet write about agentic work?',
+    );
     await expect(currentStatusLabel(page)).toHaveText('Responding');
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
 
     const labels = await page.evaluate(
       () =>
@@ -1914,6 +1948,7 @@ test.describe('Egregore loading hierarchy and activation recovery', () => {
       page,
       request,
     }) => {
+      test.slow();
       await installCorpusMismatch(page, request, mismatch);
       for (const viewport of [
         { width: 320, height: 800 },
@@ -1982,8 +2017,10 @@ test.describe('Egregore loading hierarchy and activation recovery', () => {
   }) => {
     await page.clock.install();
     await startFakeAssistant(page, 'unloading');
-    await submitQuestion(page, 'What does Jet write about agentic work?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      'What does Jet write about agentic work?',
+    );
     await page.getByRole('button', { name: /Unload/ }).click();
 
     const stack = page.getByTestId('loading-stack');
@@ -2012,8 +2049,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
     page,
   }) => {
     await startFakeAssistant(page);
-    await submitQuestion(page, 'Who is Jet?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, 'Who is Jet?');
 
     const response = page.locator('[aria-label="Conversation"] article').last();
     const citation = response.getByRole('link', {
@@ -2050,11 +2086,12 @@ test.describe('Egregore responses, citations, and scrolling', () => {
     page,
   }) => {
     await startFakeAssistant(page);
-    await submitQuestion(page, 'What does Jet write about agentic work?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      'What does Jet write about agentic work?',
+    );
 
-    await submitQuestion(page, 'What else has Jet published?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, 'What else has Jet published?');
 
     expect(
       (await runtimeMethods(page)).filter((method) => method === 'generate'),
@@ -2082,8 +2119,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
     for (const [name, width, height] of viewports) {
       await page.setViewportSize({ width, height });
       await startFakeAssistant(page);
-      await submitQuestion(page, LONG_SOURCE_TITLE);
-      await waitForCompletedResponse(page);
+      await submitQuestionAndWait(page, LONG_SOURCE_TITLE);
 
       const trigger = page.getByRole('button', { name: '1 source' });
       await expect(trigger).toHaveAttribute('aria-expanded', 'false');
@@ -2176,8 +2212,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
   }) => {
     await page.setViewportSize({ width: 430, height: 932 });
     await startFakeAssistant(page);
-    await submitQuestion(page, LONG_SOURCE_TITLE);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, LONG_SOURCE_TITLE);
 
     const response = page.locator('[aria-label="Conversation"] article').last();
     const citation = response.getByRole('link', { name: /^\[S\d+\] /u });
@@ -2202,8 +2237,10 @@ test.describe('Egregore responses, citations, and scrolling', () => {
   }) => {
     await page.setViewportSize({ width: 430, height: 932 });
     await startFakeAssistant(page, 'citations');
-    await submitQuestion(page, `${LONG_SOURCE_TITLE} ${SOURCE_SENTINEL}`);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      `${LONG_SOURCE_TITLE} ${SOURCE_SENTINEL}`,
+    );
 
     const firstDisclosure = page
       .getByTestId('response-source-disclosure')
@@ -2223,8 +2260,10 @@ test.describe('Egregore responses, citations, and scrolling', () => {
     await expect(firstLinks.first()).toContainText(LONG_SOURCE_TITLE);
     expect(await firstDisclosure.textContent()).not.toContain(SOURCE_SENTINEL);
 
-    await submitQuestion(page, `${LONG_SOURCE_TITLE} ${SOURCE_SENTINEL}`);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(
+      page,
+      `${LONG_SOURCE_TITLE} ${SOURCE_SENTINEL}`,
+    );
     const disclosures = page.getByTestId('response-source-disclosure');
     await expect(disclosures).toHaveCount(2);
     await expect(disclosures.first().getByRole('button')).toHaveAttribute(
@@ -2242,8 +2281,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
   }) => {
     await startFakeAssistant(page, 'zero-citation');
     await expect(page.getByTestId('response-source-disclosure')).toHaveCount(0);
-    await submitQuestion(page, 'What has Jet published?');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, 'What has Jet published?');
     await expect(page.getByTestId('response-source-disclosure')).toHaveCount(0);
     await expect(page.getByRole('button', { name: /sources?$/ })).toHaveCount(
       0,
@@ -2280,9 +2318,10 @@ test.describe('Egregore responses, citations, and scrolling', () => {
     // The durable contract is that the disclosure mirrors validated inline citations.
     await expect(stoppedDisclosures).toHaveCount(expectedStoppedDisclosures);
     await composer.fill('Summarize the recursive convergence hypothesis.');
+    const completedGenerationCount = await generatedResponseCount(page);
     await page.getByRole('button', { name: 'Send message' }).click();
     await expect(composer).not.toBeFocused();
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
     await expect(composer).not.toBeFocused();
     await expect(page.getByText('Stopped', { exact: true })).toHaveCount(1);
     await expect(page.getByTestId('response-source-disclosure')).toHaveCount(
@@ -2403,8 +2442,9 @@ test.describe('Egregore unsupported, failure, and exhaustion states', () => {
       .press('Enter');
     await expect(composer).toBeFocused();
     await composer.fill('Summarize the recursive convergence hypothesis.');
+    const completedGenerationCount = await generatedResponseCount(page);
     await composer.press('Enter');
-    await waitForCompletedResponse(page);
+    await waitForCompletedResponse(page, completedGenerationCount);
     await expect(
       page.getByText('Summarize the recursive convergence hypothesis.', {
         exact: true,
@@ -2415,9 +2455,10 @@ test.describe('Egregore unsupported, failure, and exhaustion states', () => {
   test('preserves the complete transcript and avoids generation after exhaustion', async ({
     page,
   }) => {
+    const supportedQuestion = 'What does Jet write about agentic work?';
+    const recoveryQuestion = 'Summarize the recursive convergence hypothesis.';
     const composer = await startFakeAssistant(page, 'exhaustion');
-    await submitQuestion(page, 'First supported question');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, supportedQuestion);
     const transcriptBefore = await page
       .locator('[aria-label="Conversation"] article')
       .allTextContents();
@@ -2462,20 +2503,16 @@ test.describe('Egregore unsupported, failure, and exhaustion states', () => {
     await expect(
       page.locator('[aria-label="Conversation"] article'),
     ).toHaveCount(0);
-    await submitQuestion(page, 'Supported question after keyboard reset');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, recoveryQuestion);
     await expect(
-      page.getByText('Supported question after keyboard reset', {
-        exact: true,
-      }),
+      page.getByText(recoveryQuestion, { exact: true }),
     ).toBeVisible();
 
     await page.goto(fakePath('exhaustion'));
     await page.getByRole('button', { name: 'Check compatibility' }).click();
     await page.getByRole('button', { name: /Load Egregore/ }).click();
     const pointerComposer = page.getByRole('textbox', { name: 'Ask Egregore' });
-    await submitQuestion(page, 'First pointer question');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, supportedQuestion);
     await submitQuestion(page, 'Second pointer question');
     await expect(
       page.getByText(
@@ -2489,10 +2526,9 @@ test.describe('Egregore unsupported, failure, and exhaustion states', () => {
     await expect(pointerComposer).toBeEnabled();
     await expect(pointerComposer).toHaveValue('');
     await expect(pointerComposer).not.toBeFocused();
-    await submitQuestion(page, 'Supported question after pointer reset');
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, recoveryQuestion);
     await expect(
-      page.getByText('Supported question after pointer reset', { exact: true }),
+      page.getByText(recoveryQuestion, { exact: true }),
     ).toBeVisible();
   });
 
@@ -2549,8 +2585,7 @@ test.describe('Egregore ClientRouter cleanup', () => {
   }) => {
     const previousQuestion = 'What does Jet write about agentic work?';
     await startFakeAssistant(page);
-    await submitQuestion(page, previousQuestion);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, previousQuestion);
     await navigateAwayThroughDock(page);
 
     const methods = await runtimeMethods(page);
@@ -2592,8 +2627,7 @@ test.describe('Egregore ClientRouter cleanup', () => {
     await expect(currentStatusLabel(page)).toHaveText('Ready');
 
     const reentryQuestion = 'Which projects connect AI and systems thinking?';
-    await submitQuestion(page, reentryQuestion);
-    await waitForCompletedResponse(page);
+    await submitQuestionAndWait(page, reentryQuestion);
     await expect(
       page.getByText(reentryQuestion, { exact: true }),
     ).toBeVisible();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -325,44 +325,33 @@ test('compact immersive navigation keeps the disclosure visually separated from 
   expect(visualGap).toBeLessThanOrEqual(10);
 });
 
-test('content card covers navigate through their dominant action everywhere', async ({
+test('every rendered content-card cover uses its dominant card destination', async ({
   page,
 }) => {
-  const cases = [
-    {
-      route: '/',
-      imageName:
-        'Retro computer with a human arm and a floating brain against a split purple and orange background',
-      destination:
-        '/blog/vibe-coding-vs-agentic-coding-why-the-distinction-matters/',
-    },
-    {
-      route: '/',
-      imageName:
-        'Digital Squad Timesheet weekly dashboard for Jet Sanchez showing a populated July work week',
-      destination: '/works/digital-squad-timesheet/',
-    },
-    {
-      route: '/blog/',
-      imageName:
-        'Retro computer with a human arm and a floating brain against a split purple and orange background',
-      destination:
-        '/blog/vibe-coding-vs-agentic-coding-why-the-distinction-matters/',
-    },
-    {
-      route: '/works/',
-      imageName:
-        'Digital Squad Timesheet weekly dashboard for Jet Sanchez showing a populated July work week',
-      destination: '/works/digital-squad-timesheet/',
-    },
-  ] as const;
-
-  for (const { route, imageName, destination } of cases) {
+  for (const route of ['/', '/blog/', '/works/']) {
     await page.goto(route);
-    const cover = page.getByRole('img', { name: imageName });
-    await expect(cover).toBeVisible();
-    await cover.click();
-    await expect(page).toHaveURL(destination);
+    const destinations = await page
+      .locator(
+        'main [data-content-card] > a[href]:has([data-content-card-media])',
+      )
+      .evaluateAll((anchors) =>
+        anchors.flatMap((anchor) => {
+          const href = anchor.getAttribute('href');
+          return href === null ? [] : [href];
+        }),
+      );
+    expect(destinations.length).toBeGreaterThan(0);
+
+    for (const destination of destinations) {
+      await page.goto(route);
+      const dominantAction = page
+        .locator(`main [data-content-card] > a[href="${destination}"]`)
+        .first();
+      const cover = dominantAction.locator('[data-content-card-media]');
+      await expect(cover).toBeVisible();
+      await cover.click();
+      await expect(page).toHaveURL(destination);
+    }
   }
 });
 

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -330,28 +330,36 @@ test('every rendered content-card cover uses its dominant card destination', asy
 }) => {
   for (const route of ['/', '/blog/', '/works/']) {
     await page.goto(route);
-    const destinations = await page
+    const bindings = await page
+      .locator('main [data-content-card] [data-content-card-media]')
+      .evaluateAll((covers) =>
+        covers.map((cover) => {
+          const dominantAction = cover.closest('a[href]');
+          const card = cover.closest('[data-content-card]');
+          return {
+            href: dominantAction?.getAttribute('href') ?? null,
+            isDirectCardAction: dominantAction?.parentElement === card,
+          };
+        }),
+      );
+    expect(bindings.length).toBeGreaterThan(0);
+    for (const binding of bindings) {
+      expect(binding.href).toBeTruthy();
+      expect(binding.isDirectCardAction).toBe(true);
+    }
+
+    const dominantAction = page
       .locator(
         'main [data-content-card] > a[href]:has([data-content-card-media])',
       )
-      .evaluateAll((anchors) =>
-        anchors.flatMap((anchor) => {
-          const href = anchor.getAttribute('href');
-          return href === null ? [] : [href];
-        }),
-      );
-    expect(destinations.length).toBeGreaterThan(0);
-
-    for (const destination of destinations) {
-      await page.goto(route);
-      const dominantAction = page
-        .locator(`main [data-content-card] > a[href="${destination}"]`)
-        .first();
-      const cover = dominantAction.locator('[data-content-card-media]');
-      await expect(cover).toBeVisible();
-      await cover.click();
-      await expect(page).toHaveURL(destination);
-    }
+      .first();
+    const destination = await dominantAction.getAttribute('href');
+    if (!destination)
+      throw new Error(`Missing content-card action on ${route}`);
+    const cover = dominantAction.locator('[data-content-card-media]');
+    await expect(cover).toBeVisible();
+    await cover.click();
+    await expect(page).toHaveURL(destination);
   }
 });
 


### PR DESCRIPTION
## Summary
- publish “The EU AI Act Is Regulating Technology That No Longer Exists” with a verified immutable 1920×1080 hero image
- include the article in public discovery and Egregore’s eligible corpus
- keep content-card and Egregore browser coverage tied to durable behavior as the archive grows
- bound Playwright concurrency to three workers locally and two in CI

## Verification
- `npm run verify`
- `npm run verify:browser` (253 passed, 19 intentional project skips)
- reviewer loop: no actionable findings

This is a content publication only; no application version, tag, or GitHub Release is created.