### PR TITLE
test: stabilize content and Egregore boundaries

### DIFF
--- a/scripts/verify-production-artifacts.ts
+++ b/scripts/verify-production-artifacts.ts
@@ -28,6 +28,7 @@ export const FORBIDDEN_PRODUCTION_ARTIFACT_MARKERS = [
   'stop-recovery',
   'late-event',
   'EGREGORE_SOURCE_SENTINEL_4a6c1b',
+  'local-first-agentic-systems',
 ] as const;
 
 export interface ForbiddenProductionArtifact {

--- a/src/data/blog/eu-ai-act-regulating-technology-no-longer-exists.mdx
+++ b/src/data/blog/eu-ai-act-regulating-technology-no-longer-exists.mdx
@@ -19,7 +19,7 @@ image:
 
 Perhaps the most revealing thing about the EU AI Act today is that it regulates an idea of artificial intelligence that is already obsolete.
 
-Article 50 is a perfect example. Its underlying model of the world is simple: humans make human things, AI makes AI things, and therefore AI things should carry some persistent signal identifying them as such.
+[Article 50](https://artificialintelligenceact.eu/article/50/) is a perfect example. Its underlying model of the world is simple: humans make human things, AI makes AI things, and therefore AI things should carry some persistent signal identifying them as such.
 
 That framework might have sounded coherent in 2023. But in 2026, it is almost embarrassingly primitive.
 

--- a/src/data/blog/spider-man-brand-new-day.mdx
+++ b/src/data/blog/spider-man-brand-new-day.mdx
@@ -40,6 +40,8 @@ Responsibility isn’t a lesson Peter learns once and permanently completes. He 
 
 But Peter’s problem in *Brand New Day* isn’t that he’s failed to learn sacrifice. If anything, he’s learned it too completely.
 
+## Responsibility Without Self-Erasure
+
 After *No Way Home*, Peter has transformed responsibility into an excuse for isolation. He has concluded that loving people means protecting them from himself, even if that requires withholding the truth, making their decisions for them and disappearing from their lives. It initially resembles the purest possible expression of selfless heroism. Peter accepts the loss, asks for nothing and continues helping people who may never know what he surrendered for them.
 
 Yet *Brand New Day* gradually exposes this as an incomplete and ultimately destructive understanding of what it means to be Spider-Man. Peter has confused responsibility with self-erasure. He has mistaken loneliness for moral clarity.
@@ -50,11 +52,15 @@ This is especially impressive because *Brand New Day* doesn’t reject the earli
 
 In doing so, it achieves something I hadn’t thought entirely possible: it retroactively changes what those films mean.
 
+## Becoming Spider-Man
+
 In retrospect, the previous trilogy can now be understood as a prolonged story of Peter becoming Spider-Man. He had the powers. He wore the suit. He fought alongside the Avengers and helped save the universe. But his life remained supported by friends, mentors, inherited technology and an interconnected heroic world that often softened the traditional tension between Peter Parker and Spider-Man.
 
 Before *Brand New Day*, saying that this version of Peter hadn’t fully become Spider-Man could sound like an external criticism of the earlier films, or essentially a complaint about what they had failed to provide. After *Brand New Day*, it can be read as the intended shape of his development. The new film makes the earlier trilogy feel like a prehistory without diminishing its importance. Everything mattered. It simply hadn’t reached its final meaning yet.
 
 That’s a difficult tonal reconciliation, and the film manages it with remarkable confidence.
+
+## A Spider-Man Film With Weight
 
 From its opening movements, *Brand New Day* feels tactile in a way Marvel films have rarely attempted in recent years. There’s weight to the world and to Spider-Man’s movement through it. The practical suits take center stage here, as does the emphasis on physical swinging and action that understands Spider-Man as a body moving through space rather than a digital figure simply traversing it. Holland rises to that physicality with a noticeably more mature performance, carrying himself like a Spider-Man who has finally grown into both the burden and the capability of the role.
 
@@ -80,11 +86,15 @@ There are moments when it drifts visually and stylistically back toward the fami
 
 The film’s primary antagonist, apart from its fresh if somewhat underused rogues’ gallery, isn’t a conventional marquee villain hidden beneath prosthetics or CGI. It’s an initially unseen force that follows Peter through the people he saves, fights, knows and loves. That gives the story a distinctive narrative and psychological edge, and the film mostly refuses to squander it, even with the future of the wider MCU breathing down its neck.
 
+## The Spider Within
+
 More importantly, the threat isn’t merely something Peter must defeat. It literalizes the division within him.
 
 As the mutation advances, Peter increasingly gives himself over to instincts that are recognizably arachnid: isolation, territoriality and the rejection of attachment. A typical spider is solitary, and the mutation amplifies that nature within him. The more Peter withdraws from the people he loves and suppresses the part of himself that needs them, the stronger those instincts become.
 
 His physical destabilization is therefore inseparable from his emotional and philosophical crisis. Peter has divided himself into two competing identities: Spider-Man, whom he understands as duty, power and sacrifice, and Peter, whom he increasingly treats as a source of weakness, longing and dangerous attachment. The more completely he tries to become Spider-Man at Peter’s expense, the less stable either identity becomes.
+
+## He Is Both
 
 That’s why the people Peter allows back into his life matter so much.
 
@@ -99,6 +109,8 @@ Peter doesn’t stabilize his mutation by defeating or suppressing the spider wi
 His capacity for love, trust and attachment is what keeps Spider-Man human. And eventually, his willingness to be known, helped and loved is what finally allows him to reach the height of his powers.
 
 When Peter lets others in again, he’s not only reclaiming his relationships. He’s allowing himself to breathe.
+
+## The Best Since Spider-Man 2
 
 Taken together, the film’s minor imperfections keep it, by the narrowest margin, below *Spider-Man 2* for me. Raimi’s film possesses an almost impossibly pure structural, narrative and thematic simplicity. Every element seems organized around the same question: can Peter accept the cost of being Spider-Man? Its clarity is elemental.
 

--- a/src/features/egregore/EgregoreExperience.tsx
+++ b/src/features/egregore/EgregoreExperience.tsx
@@ -53,6 +53,7 @@ import {
   FakeRuntimeRecorder,
   type FakeRuntimeCall,
 } from './runtime/fakeRuntime';
+import { createFakeKnowledgeRepository } from './runtime/fakeKnowledge';
 import {
   configureFakeCitationSelection,
   configureFakeSourceSentinel,
@@ -234,7 +235,10 @@ function createTestBuildDependencies(): EgregoreDependencies {
             },
       removeCurrent: async () => undefined,
     };
-    const repository = new StaticKnowledgeRepository();
+    const repository =
+      configuration.knowledgeSource === 'published'
+        ? new StaticKnowledgeRepository()
+        : createFakeKnowledgeRepository();
     exposeE2EAudit(recorder);
 
     return {

--- a/src/features/egregore/runtime/fakeKnowledge.ts
+++ b/src/features/egregore/runtime/fakeKnowledge.ts
@@ -1,0 +1,211 @@
+import type { LoadedKnowledgeBase } from '../corpus/repository';
+import type {
+  ChunkId,
+  DocumentId,
+  KnowledgeChunk,
+  KnowledgeDocument,
+  KnowledgePackage,
+  KnowledgeSection,
+  SectionId,
+} from '../corpus/types';
+import { estimateTokens } from '../tokenEstimate';
+import {
+  buildSearchIndexArtifact,
+  loadSearchIndex,
+} from '../selection/searchIndex';
+import { serializeSourcePayload } from '../sourcePayload';
+
+const CORPUS_VERSION = 'a'.repeat(64);
+const INDEX_SHA256 = 'b'.repeat(64);
+
+const documents: KnowledgeDocument[] = [
+  {
+    id: 'blog:local-first-agentic-systems',
+    order: 0,
+    collection: 'blog',
+    slug: 'local-first-agentic-systems',
+    title: 'Local-First Agentic Systems',
+    description: 'How local AI, agentic work, and systems thinking connect.',
+    canonicalUrl: 'https://jetsanchez.com/blog/local-first-agentic-systems/',
+    tags: ['local AI', 'agentic work', 'systems thinking'],
+    author: 'Jet Sanchez',
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    sourcePath: 'src/data/blog/local-first-agentic-systems.mdx',
+    sourceHash: '1'.repeat(64),
+  },
+  {
+    id: 'works:recursive-convergence-hypothesis',
+    order: 1,
+    collection: 'works',
+    slug: 'recursive-convergence-hypothesis',
+    title:
+      'The Recursive Convergence Hypothesis: Emergent Sentience as a Structural Attractor of Recursive ASI',
+    description: 'Research on recursive systems and emergent sentience.',
+    canonicalUrl:
+      'https://jetsanchez.com/works/recursive-convergence-hypothesis/',
+    tags: ['AI research', 'recursive systems'],
+    author: 'Jet Sanchez',
+    publishedAt: '2026-01-02T00:00:00.000Z',
+    sourcePath: 'src/data/works/recursive-convergence-hypothesis.mdx',
+    sourceHash: '2'.repeat(64),
+  },
+];
+
+const sections: KnowledgeSection[] = [
+  {
+    id: 'blog:local-first-agentic-systems#connections',
+    documentId: 'blog:local-first-agentic-systems',
+    heading: 'Connecting local AI and agentic work',
+    headingPath: ['Connecting local AI and agentic work'],
+    order: 0,
+  },
+  {
+    id: 'works:recursive-convergence-hypothesis#structural-attractor',
+    documentId: 'works:recursive-convergence-hypothesis',
+    heading: 'The structural-attractor argument',
+    headingPath: ['The structural-attractor argument'],
+    order: 0,
+  },
+];
+
+function chunk(
+  id: ChunkId,
+  documentId: DocumentId,
+  sectionId: SectionId,
+  text: string,
+  order: number,
+  contentHash: string,
+): KnowledgeChunk {
+  return {
+    id,
+    documentId,
+    sectionId,
+    text,
+    estimatedTokens: estimateTokens(text),
+    order,
+    contentHash,
+    sameTextOccurrence: 0,
+  };
+}
+
+const chunks: KnowledgeChunk[] = [
+  chunk(
+    `blog:local-first-agentic-systems#connections:${'3'.repeat(64)}:0`,
+    'blog:local-first-agentic-systems',
+    'blog:local-first-agentic-systems#connections',
+    "Jet's published work connects local-first AI with agentic work and systems thinking.",
+    0,
+    '3'.repeat(64),
+  ),
+  chunk(
+    `blog:local-first-agentic-systems#connections:${'4'.repeat(64)}:0`,
+    'blog:local-first-agentic-systems',
+    'blog:local-first-agentic-systems#connections',
+    'The practical projects explore browser-local tools, technical workflows, and grounded assistance.',
+    1,
+    '4'.repeat(64),
+  ),
+  chunk(
+    `works:recursive-convergence-hypothesis#structural-attractor:${'5'.repeat(64)}:0`,
+    'works:recursive-convergence-hypothesis',
+    'works:recursive-convergence-hypothesis#structural-attractor',
+    'The recursive convergence hypothesis develops a structural-attractor argument about emergent sentience in recursive ASI.',
+    0,
+    '5'.repeat(64),
+  ),
+  chunk(
+    `works:recursive-convergence-hypothesis#structural-attractor:${'6'.repeat(64)}:0`,
+    'works:recursive-convergence-hypothesis',
+    'works:recursive-convergence-hypothesis#structural-attractor',
+    'The research connects recursive systems, AI safety, and the conditions under which sentience could emerge.',
+    1,
+    '6'.repeat(64),
+  ),
+];
+
+const knowledgePackage: KnowledgePackage = {
+  schemaVersion: '1.0.0',
+  segmentationVersion: '1.0.0',
+  corpusVersion: CORPUS_VERSION,
+  sourceCommit: 'egregore-fake-knowledge',
+  documents,
+  sections,
+  chunks,
+  statistics: {
+    documentCount: documents.length,
+    sectionCount: sections.length,
+    chunkCount: chunks.length,
+    estimatedContentTokens: chunks.reduce(
+      (total, item) => total + item.estimatedTokens,
+      0,
+    ),
+    fullCorpusKnowledgeTokens: serializeSourcePayload(
+      chunks.map((item, index) => {
+        const document = documents.find(({ id }) => id === item.documentId)!;
+        const section = sections.find(({ id }) => id === item.sectionId)!;
+        return {
+          citationId: `S${index + 1}` as `S${number}`,
+          documentId: document.id,
+          sectionId: section.id,
+          chunkId: item.id,
+          title: document.title,
+          canonicalUrl: document.canonicalUrl,
+          heading: section.heading,
+          text: item.text,
+        };
+      }),
+    ).estimatedTokens,
+  },
+};
+
+async function buildFakeKnowledgeBase(): Promise<LoadedKnowledgeBase> {
+  const searchArtifact = buildSearchIndexArtifact(knowledgePackage);
+  const documentsById = new Map(
+    documents.map((document) => [document.id, document]),
+  );
+  const sectionsById = new Map(
+    sections.map((section) => [section.id, section]),
+  );
+  const chunksById = new Map(chunks.map((item) => [item.id, item]));
+  const neighborsByChunkId = new Map<
+    ChunkId,
+    { previous?: ChunkId; next?: ChunkId }
+  >([
+    [chunks[0].id, { next: chunks[1].id }],
+    [chunks[1].id, { previous: chunks[0].id }],
+    [chunks[2].id, { next: chunks[3].id }],
+    [chunks[3].id, { previous: chunks[2].id }],
+  ]);
+
+  return {
+    package: knowledgePackage,
+    searchIndex: await loadSearchIndex(searchArtifact, CORPUS_VERSION),
+    documentsById,
+    sectionsById,
+    chunksById,
+    neighborsByChunkId,
+    indexSha256: INDEX_SHA256,
+    indexConfigVersion: searchArtifact.indexConfigVersion,
+    miniSearchVersion: searchArtifact.miniSearchVersion,
+    stemmerVersion: searchArtifact.stemmerVersion,
+  };
+}
+
+export function createFakeKnowledgeRepository(): {
+  load: (signal?: AbortSignal) => Promise<LoadedKnowledgeBase>;
+  unload: () => void;
+} {
+  let loaded: Promise<LoadedKnowledgeBase> | undefined;
+  return {
+    load: (signal) => {
+      if (signal?.aborted === true) {
+        return Promise.reject(new DOMException('Aborted', 'AbortError'));
+      }
+      loaded ??= buildFakeKnowledgeBase();
+      return loaded;
+    },
+    unload: () => {
+      loaded = undefined;
+    },
+  };
+}

--- a/src/features/egregore/runtime/fakeKnowledge.ts
+++ b/src/features/egregore/runtime/fakeKnowledge.ts
@@ -15,150 +15,150 @@ import {
 } from '../selection/searchIndex';
 import { serializeSourcePayload } from '../sourcePayload';
 
-const CORPUS_VERSION = 'a'.repeat(64);
-const INDEX_SHA256 = 'b'.repeat(64);
-
-const documents: KnowledgeDocument[] = [
-  {
-    id: 'blog:local-first-agentic-systems',
-    order: 0,
-    collection: 'blog',
-    slug: 'local-first-agentic-systems',
-    title: 'Local-First Agentic Systems',
-    description: 'How local AI, agentic work, and systems thinking connect.',
-    canonicalUrl: 'https://jetsanchez.com/blog/local-first-agentic-systems/',
-    tags: ['local AI', 'agentic work', 'systems thinking'],
-    author: 'Jet Sanchez',
-    publishedAt: '2026-01-01T00:00:00.000Z',
-    sourcePath: 'src/data/blog/local-first-agentic-systems.mdx',
-    sourceHash: '1'.repeat(64),
-  },
-  {
-    id: 'works:recursive-convergence-hypothesis',
-    order: 1,
-    collection: 'works',
-    slug: 'recursive-convergence-hypothesis',
-    title:
-      'The Recursive Convergence Hypothesis: Emergent Sentience as a Structural Attractor of Recursive ASI',
-    description: 'Research on recursive systems and emergent sentience.',
-    canonicalUrl:
-      'https://jetsanchez.com/works/recursive-convergence-hypothesis/',
-    tags: ['AI research', 'recursive systems'],
-    author: 'Jet Sanchez',
-    publishedAt: '2026-01-02T00:00:00.000Z',
-    sourcePath: 'src/data/works/recursive-convergence-hypothesis.mdx',
-    sourceHash: '2'.repeat(64),
-  },
-];
-
-const sections: KnowledgeSection[] = [
-  {
-    id: 'blog:local-first-agentic-systems#connections',
-    documentId: 'blog:local-first-agentic-systems',
-    heading: 'Connecting local AI and agentic work',
-    headingPath: ['Connecting local AI and agentic work'],
-    order: 0,
-  },
-  {
-    id: 'works:recursive-convergence-hypothesis#structural-attractor',
-    documentId: 'works:recursive-convergence-hypothesis',
-    heading: 'The structural-attractor argument',
-    headingPath: ['The structural-attractor argument'],
-    order: 0,
-  },
-];
-
-function chunk(
-  id: ChunkId,
-  documentId: DocumentId,
-  sectionId: SectionId,
-  text: string,
-  order: number,
-  contentHash: string,
-): KnowledgeChunk {
-  return {
-    id,
-    documentId,
-    sectionId,
-    text,
-    estimatedTokens: estimateTokens(text),
-    order,
-    contentHash,
-    sameTextOccurrence: 0,
-  };
-}
-
-const chunks: KnowledgeChunk[] = [
-  chunk(
-    `blog:local-first-agentic-systems#connections:${'3'.repeat(64)}:0`,
-    'blog:local-first-agentic-systems',
-    'blog:local-first-agentic-systems#connections',
-    "Jet's published work connects local-first AI with agentic work and systems thinking.",
-    0,
-    '3'.repeat(64),
-  ),
-  chunk(
-    `blog:local-first-agentic-systems#connections:${'4'.repeat(64)}:0`,
-    'blog:local-first-agentic-systems',
-    'blog:local-first-agentic-systems#connections',
-    'The practical projects explore browser-local tools, technical workflows, and grounded assistance.',
-    1,
-    '4'.repeat(64),
-  ),
-  chunk(
-    `works:recursive-convergence-hypothesis#structural-attractor:${'5'.repeat(64)}:0`,
-    'works:recursive-convergence-hypothesis',
-    'works:recursive-convergence-hypothesis#structural-attractor',
-    'The recursive convergence hypothesis develops a structural-attractor argument about emergent sentience in recursive ASI.',
-    0,
-    '5'.repeat(64),
-  ),
-  chunk(
-    `works:recursive-convergence-hypothesis#structural-attractor:${'6'.repeat(64)}:0`,
-    'works:recursive-convergence-hypothesis',
-    'works:recursive-convergence-hypothesis#structural-attractor',
-    'The research connects recursive systems, AI safety, and the conditions under which sentience could emerge.',
-    1,
-    '6'.repeat(64),
-  ),
-];
-
-const knowledgePackage: KnowledgePackage = {
-  schemaVersion: '1.0.0',
-  segmentationVersion: '1.0.0',
-  corpusVersion: CORPUS_VERSION,
-  sourceCommit: 'egregore-fake-knowledge',
-  documents,
-  sections,
-  chunks,
-  statistics: {
-    documentCount: documents.length,
-    sectionCount: sections.length,
-    chunkCount: chunks.length,
-    estimatedContentTokens: chunks.reduce(
-      (total, item) => total + item.estimatedTokens,
-      0,
-    ),
-    fullCorpusKnowledgeTokens: serializeSourcePayload(
-      chunks.map((item, index) => {
-        const document = documents.find(({ id }) => id === item.documentId)!;
-        const section = sections.find(({ id }) => id === item.sectionId)!;
-        return {
-          citationId: `S${index + 1}` as `S${number}`,
-          documentId: document.id,
-          sectionId: section.id,
-          chunkId: item.id,
-          title: document.title,
-          canonicalUrl: document.canonicalUrl,
-          heading: section.heading,
-          text: item.text,
-        };
-      }),
-    ).estimatedTokens,
-  },
-};
-
 async function buildFakeKnowledgeBase(): Promise<LoadedKnowledgeBase> {
+  const CORPUS_VERSION = 'a'.repeat(64);
+  const INDEX_SHA256 = 'b'.repeat(64);
+
+  const documents: KnowledgeDocument[] = [
+    {
+      id: 'blog:local-first-agentic-systems',
+      order: 0,
+      collection: 'blog',
+      slug: 'local-first-agentic-systems',
+      title: 'Local-First Agentic Systems',
+      description: 'How local AI, agentic work, and systems thinking connect.',
+      canonicalUrl: 'https://jetsanchez.com/blog/local-first-agentic-systems/',
+      tags: ['local AI', 'agentic work', 'systems thinking'],
+      author: 'Jet Sanchez',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      sourcePath: 'src/data/blog/local-first-agentic-systems.mdx',
+      sourceHash: '1'.repeat(64),
+    },
+    {
+      id: 'works:recursive-convergence-hypothesis',
+      order: 1,
+      collection: 'works',
+      slug: 'recursive-convergence-hypothesis',
+      title:
+        'The Recursive Convergence Hypothesis: Emergent Sentience as a Structural Attractor of Recursive ASI',
+      description: 'Research on recursive systems and emergent sentience.',
+      canonicalUrl:
+        'https://jetsanchez.com/works/recursive-convergence-hypothesis/',
+      tags: ['AI research', 'recursive systems'],
+      author: 'Jet Sanchez',
+      publishedAt: '2026-01-02T00:00:00.000Z',
+      sourcePath: 'src/data/works/recursive-convergence-hypothesis.mdx',
+      sourceHash: '2'.repeat(64),
+    },
+  ];
+
+  const sections: KnowledgeSection[] = [
+    {
+      id: 'blog:local-first-agentic-systems#connections',
+      documentId: 'blog:local-first-agentic-systems',
+      heading: 'Connecting local AI and agentic work',
+      headingPath: ['Connecting local AI and agentic work'],
+      order: 0,
+    },
+    {
+      id: 'works:recursive-convergence-hypothesis#structural-attractor',
+      documentId: 'works:recursive-convergence-hypothesis',
+      heading: 'The structural-attractor argument',
+      headingPath: ['The structural-attractor argument'],
+      order: 0,
+    },
+  ];
+
+  function chunk(
+    id: ChunkId,
+    documentId: DocumentId,
+    sectionId: SectionId,
+    text: string,
+    order: number,
+    contentHash: string,
+  ): KnowledgeChunk {
+    return {
+      id,
+      documentId,
+      sectionId,
+      text,
+      estimatedTokens: estimateTokens(text),
+      order,
+      contentHash,
+      sameTextOccurrence: 0,
+    };
+  }
+
+  const chunks: KnowledgeChunk[] = [
+    chunk(
+      `blog:local-first-agentic-systems#connections:${'3'.repeat(64)}:0`,
+      'blog:local-first-agentic-systems',
+      'blog:local-first-agentic-systems#connections',
+      "Jet's published work connects local-first AI with agentic work and systems thinking.",
+      0,
+      '3'.repeat(64),
+    ),
+    chunk(
+      `blog:local-first-agentic-systems#connections:${'4'.repeat(64)}:0`,
+      'blog:local-first-agentic-systems',
+      'blog:local-first-agentic-systems#connections',
+      'The practical projects explore browser-local tools, technical workflows, and grounded assistance.',
+      1,
+      '4'.repeat(64),
+    ),
+    chunk(
+      `works:recursive-convergence-hypothesis#structural-attractor:${'5'.repeat(64)}:0`,
+      'works:recursive-convergence-hypothesis',
+      'works:recursive-convergence-hypothesis#structural-attractor',
+      'The recursive convergence hypothesis develops a structural-attractor argument about emergent sentience in recursive ASI.',
+      0,
+      '5'.repeat(64),
+    ),
+    chunk(
+      `works:recursive-convergence-hypothesis#structural-attractor:${'6'.repeat(64)}:0`,
+      'works:recursive-convergence-hypothesis',
+      'works:recursive-convergence-hypothesis#structural-attractor',
+      'The research connects recursive systems, AI safety, and the conditions under which sentience could emerge.',
+      1,
+      '6'.repeat(64),
+    ),
+  ];
+
+  const knowledgePackage: KnowledgePackage = {
+    schemaVersion: '1.0.0',
+    segmentationVersion: '1.0.0',
+    corpusVersion: CORPUS_VERSION,
+    sourceCommit: 'egregore-fake-knowledge',
+    documents,
+    sections,
+    chunks,
+    statistics: {
+      documentCount: documents.length,
+      sectionCount: sections.length,
+      chunkCount: chunks.length,
+      estimatedContentTokens: chunks.reduce(
+        (total, item) => total + item.estimatedTokens,
+        0,
+      ),
+      fullCorpusKnowledgeTokens: serializeSourcePayload(
+        chunks.map((item, index) => {
+          const document = documents.find(({ id }) => id === item.documentId)!;
+          const section = sections.find(({ id }) => id === item.sectionId)!;
+          return {
+            citationId: `S${index + 1}` as `S${number}`,
+            documentId: document.id,
+            sectionId: section.id,
+            chunkId: item.id,
+            title: document.title,
+            canonicalUrl: document.canonicalUrl,
+            heading: section.heading,
+            text: item.text,
+          };
+        }),
+      ).estimatedTokens,
+    },
+  };
+
   const searchArtifact = buildSearchIndexArtifact(knowledgePackage);
   const documentsById = new Map(
     documents.map((document) => [document.id, document]),

--- a/src/features/egregore/runtime/fakeScenario.ts
+++ b/src/features/egregore/runtime/fakeScenario.ts
@@ -4,6 +4,7 @@ import { serializeSourcePayload } from '../sourcePayload';
 
 export const FAKE_SCENARIOS = [
   'default',
+  'published-corpus',
   'checking',
   'unsupported',
   'load-failure',
@@ -42,6 +43,7 @@ type ScenarioFailurePoint =
 
 export interface FakeScenarioConfiguration {
   responseChunks: readonly string[];
+  knowledgeSource: 'fixture' | 'published';
   failures?: Partial<Record<ScenarioFailurePoint, true | number>>;
   capabilityDelayMs?: number;
   loadDelayMs?: number;
@@ -68,9 +70,9 @@ const LONG_RESPONSE_CHUNKS = [
 
 const FAKE_SOURCE_SENTINEL = 'EGREGORE_SOURCE_SENTINEL_4a6c1b';
 
-export function getFakeScenarioConfiguration(
-  scenario: FakeScenario,
-): FakeScenarioConfiguration {
+type FakeScenarioDetails = Omit<FakeScenarioConfiguration, 'knowledgeSource'>;
+
+function getFakeScenarioDetails(scenario: FakeScenario): FakeScenarioDetails {
   switch (scenario) {
     case 'checking':
       return {
@@ -139,8 +141,18 @@ export function getFakeScenarioConfiguration(
         emitLateChunkAfterCancellation: true,
       };
     case 'default':
+    case 'published-corpus':
       return { responseChunks: DEFAULT_RESPONSE_CHUNKS, capabilityDelayMs: 50 };
   }
+}
+
+export function getFakeScenarioConfiguration(
+  scenario: FakeScenario,
+): FakeScenarioConfiguration {
+  return {
+    ...getFakeScenarioDetails(scenario),
+    knowledgeSource: scenario === 'published-corpus' ? 'published' : 'fixture',
+  };
 }
 
 export function configureFakeCitationSelection(

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -6,6 +6,7 @@ import {
   type Locator,
   type Page,
 } from '@playwright/test';
+import { publishedContent } from '../support/publishedContent';
 
 const suggestedQuestions = [
   'What does Jet write about agentic work?',
@@ -162,6 +163,19 @@ async function sitemapHtmlRoutes(request: APIRequestContext) {
   return [...routes].sort();
 }
 
+const publicHtmlRoutes = [
+  '/',
+  '/about/',
+  '/blog/',
+  '/chatbot/',
+  '/contact/',
+  '/licenses/egregore/',
+  '/works/',
+  ...publishedContent().map(({ route }) => route),
+].filter((route, index, routes) => routes.indexOf(route) === index);
+
+const accessibilityRoutes = [...publicHtmlRoutes, '/tools/'].sort();
+
 async function focusWithKeyboard(page: Page, target: Locator) {
   await expect(target).toBeVisible();
   await expect(target).toBeEnabled();
@@ -187,41 +201,33 @@ async function expectLifecycleAccessibility(page: Page, announcement: string) {
   await expect(compactStatus).not.toHaveAttribute('role', /.+/);
 }
 
-for (const theme of ['light', 'dark'] as const) {
-  test(`every sitemap HTML page plus the dormant route is axe-clean in ${theme} theme`, async ({
-    page,
-    request,
-  }, testInfo) => {
-    test.skip(testInfo.project.name !== 'chromium');
-    test.slow();
+test('the accessibility route matrix covers every sitemap HTML page plus the dormant route', async ({
+  request,
+}) => {
+  const sitemapRoutes = await sitemapHtmlRoutes(request);
+  expect(sitemapRoutes).toContain('/chatbot/');
+  expect(sitemapRoutes).not.toContain('/tools/');
+  expect(accessibilityRoutes).toEqual([...sitemapRoutes, '/tools/'].sort());
+});
 
-    await page.addInitScript((selectedTheme) => {
-      localStorage.setItem('theme', selectedTheme);
-    }, theme);
+for (const route of accessibilityRoutes) {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${route} is axe-clean in ${theme} theme`, async ({
+      page,
+    }, testInfo) => {
+      test.skip(testInfo.project.name !== 'chromium');
 
-    const sitemapRoutes = await sitemapHtmlRoutes(request);
-    expect(sitemapRoutes).toContain('/chatbot/');
-    expect(sitemapRoutes).not.toContain('/tools/');
+      await page.addInitScript((selectedTheme) => {
+        localStorage.setItem('theme', selectedTheme);
+      }, theme);
 
-    const failures = [];
-    for (const route of [...sitemapRoutes, '/tools/']) {
       await page.goto(route);
       await expect(page.locator('html')).toHaveClass(
         theme === 'dark' ? /\bdark\b/u : /^(?!.*\bdark\b)/u,
       );
-      for (const violation of await seriousAxeViolations(page)) {
-        for (const node of violation.nodes) {
-          failures.push({
-            route,
-            rule: violation.id,
-            target: node.target,
-            summary: node.failureSummary,
-          });
-        }
-      }
-    }
-    expect(failures, `axe violations in ${theme} theme`).toEqual([]);
-  });
+      await expectNoSeriousAxeViolations(page, `${route} in ${theme} theme`);
+    });
+  }
 }
 
 test('Egregore introduction, ready, and response states remain accessible by keyboard', async ({
@@ -314,7 +320,7 @@ test('Egregore recoverable error is axe-clean and keyboard operable', async ({
       body: 'Temporarily unavailable',
     });
   });
-  await page.goto('/chatbot/?runtime=fake');
+  await page.goto('/chatbot/?runtime=fake&scenario=published-corpus');
 
   const compatibility = page.getByRole('button', {
     name: 'Check compatibility',

--- a/tests/e2e/egregore.spec.ts
+++ b/tests/e2e/egregore.spec.ts
@@ -35,6 +35,7 @@ const SOURCE_SENTINEL = 'EGREGORE_SOURCE_SENTINEL_4a6c1b';
 
 type FakeScenario =
   | 'default'
+  | 'published-corpus'
   | 'checking'
   | 'unsupported'
   | 'load-failure'
@@ -623,7 +624,7 @@ test.describe('Egregore consent and local privacy', () => {
     await installFetchAudit(page);
     const browserRequests: Request[] = [];
     page.on('request', (request) => browserRequests.push(request));
-    await page.goto(fakePath());
+    await page.goto(fakePath('published-corpus'));
     await page.waitForLoadState('networkidle');
     browserRequests.length = 0;
     await page.evaluate(() => {
@@ -737,6 +738,25 @@ test.describe('Egregore consent and local privacy', () => {
         allowBrowserCookie: isApplicationAsset || isAnalytics,
       });
     }
+  });
+
+  test('keeps lifecycle scenarios independent from the published corpus', async ({
+    page,
+  }) => {
+    await installFetchAudit(page);
+    await startFakeAssistant(page);
+    await submitQuestionAndWait(
+      page,
+      'What does Jet write about agentic work?',
+    );
+
+    expect(
+      (await auditedFetches(page)).filter(({ url }) =>
+        CORPUS_PATHS.includes(
+          new URL(url).pathname as (typeof CORPUS_PATHS)[number],
+        ),
+      ),
+    ).toEqual([]);
   });
 });
 
@@ -1956,7 +1976,7 @@ test.describe('Egregore loading hierarchy and activation recovery', () => {
         { width: 1280, height: 800 },
       ]) {
         await page.setViewportSize(viewport);
-        await page.goto(fakePath());
+        await page.goto(fakePath('published-corpus'));
         await page.getByRole('button', { name: 'Check compatibility' }).click();
         const slot = page.getByTestId('activation-status-message');
         const activationMain = page.getByTestId('activation-main');
@@ -2048,7 +2068,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
   test('grounds a profile question in the canonical About source without exposing uncited context', async ({
     page,
   }) => {
-    await startFakeAssistant(page);
+    await startFakeAssistant(page, 'published-corpus');
     await submitQuestionAndWait(page, 'Who is Jet?');
 
     const response = page.locator('[aria-label="Conversation"] article').last();
@@ -2085,7 +2105,7 @@ test.describe('Egregore responses, citations, and scrolling', () => {
   test('keeps a representative live-corpus follow-up within one local session', async ({
     page,
   }) => {
-    await startFakeAssistant(page);
+    await startFakeAssistant(page, 'published-corpus');
     await submitQuestionAndWait(
       page,
       'What does Jet write about agentic work?',

--- a/tests/unit/build/productionArtifacts.test.ts
+++ b/tests/unit/build/productionArtifacts.test.ts
@@ -124,6 +124,7 @@ describe('ordinary production artifact containment', () => {
       'stop-recovery',
       'late-event',
       'EGREGORE_SOURCE_SENTINEL_4a6c1b',
+      'local-first-agentic-systems',
       'egregore:qualification-observation',
       'retrieval-context-selection-ms',
     ];

--- a/tests/unit/egregore/fakeKnowledge.test.ts
+++ b/tests/unit/egregore/fakeKnowledge.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { EGREGORE_CONTEXT } from '../../../src/features/egregore/config';
+import { createFakeKnowledgeRepository } from '../../../src/features/egregore/runtime/fakeKnowledge';
+import { rankAndPackContext } from '../../../src/features/egregore/selection/rankAndPack';
+
+describe('Egregore fake knowledge', () => {
+  it('provides a stable searchable corpus with duplicate and distinct document citations', async () => {
+    const repository = createFakeKnowledgeRepository();
+    const knowledgeBase = await repository.load();
+
+    const selection = rankAndPackContext({
+      query: 'What does Jet write about agentic work?',
+      knowledgeBase,
+      budget: EGREGORE_CONTEXT,
+    });
+
+    expect(selection.sources.length).toBeGreaterThanOrEqual(3);
+    expect(selection.sources[0]?.text).toContain('agentic work');
+    expect(
+      selection.sources.some(
+        (source, index) =>
+          index > 0 &&
+          source.canonicalUrl === selection.sources[0]?.canonicalUrl,
+      ),
+    ).toBe(true);
+    expect(
+      selection.sources.some(
+        (source) => source.canonicalUrl !== selection.sources[0]?.canonicalUrl,
+      ),
+    ).toBe(true);
+
+    repository.unload();
+    await expect(repository.load()).resolves.toMatchObject({
+      package: { corpusVersion: knowledgeBase.package.corpusVersion },
+    });
+  });
+});

--- a/tests/unit/egregore/fakeScenario.test.ts
+++ b/tests/unit/egregore/fakeScenario.test.ts
@@ -81,6 +81,7 @@ describe('Egregore fake browser scenarios', () => {
 
     expect(FAKE_SCENARIOS).toEqual([
       'default',
+      'published-corpus',
       'checking',
       'unsupported',
       'load-failure',
@@ -157,6 +158,11 @@ describe('Egregore fake browser scenarios', () => {
     );
     expect(getFakeScenarioConfiguration('default')).toMatchObject({
       capabilityDelayMs: 50,
+      knowledgeSource: 'fixture',
+    });
+    expect(getFakeScenarioConfiguration('published-corpus')).toMatchObject({
+      capabilityDelayMs: 50,
+      knowledgeSource: 'published',
     });
   });
 


### PR DESCRIPTION
## What changed

- isolates Egregore lifecycle and interaction scenarios from the mutable published corpus with a small deterministic MiniSearch fixture
- retains explicit published-corpus integration scenarios for network privacy, corpus mismatch, profile grounding, and multi-turn behavior
- gives each sitemap accessibility route its own browser-test identity and timeout
- adds a durable production-artifact marker preventing fake knowledge from entering shipped JavaScript
- links the EU AI Act essay to Article 50 and adds six thematic H2s to the Spider-Man review without rewriting its prose

## Why

Adding a published post could change or slow unrelated Egregore lifecycle tests because every fake scenario loaded the generated production corpus. The new boundary keeps lifecycle contracts stable while preserving deliberate integration coverage for publication data. The production-artifact assertion also closes a tree-shaking false negative identified during review.

## Verification

- temporary newest `status: published` + `assistant: true` article passed archive, Home, filter-count, sitemap/content-discovery, corpus-identity, published-corpus, and lifecycle-isolation checks, then was removed
- `npm run verify` — 556 tests passed; content, docs, build, and production-artifact gates passed
- `npm run verify:browser` — 287 passed, 49 intentional project skips
- focused post-review browser rerun — 8 passed across Chromium and mobile Chromium
- final code-quality re-review — no actionable findings
